### PR TITLE
Feature 57 stratum method details

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,3 +1,3 @@
 linters: linters_with_defaults(
    line_length_linter = line_length_linter(110),
-   object_usage_linter = NULL)
+   object_name_linter = object_name_linter(styles = c("snake_case", "SNAKE_CASE", "UPPERCASE", "lowercase", "symbols")))

--- a/.lintr
+++ b/.lintr
@@ -1,3 +1,4 @@
 linters: linters_with_defaults(
    line_length_linter = line_length_linter(110),
-   object_name_linter = object_name_linter(styles = c("snake_case", "SNAKE_CASE", "UPPERCASE", "lowercase", "symbols")))
+   object_name_linter = object_name_linter(styles = c("snake_case", "SNAKE_CASE", "UPPERCASE", "lowercase", "symbols")),
+   object_usage_linter = NULL)

--- a/R/detail_comm_class.R
+++ b/R/detail_comm_class.R
@@ -58,7 +58,7 @@ create_comm_class_header_ui <- function(result) {
         style = "color: var(--vb-green); font-weight: 600;"
       ),
       if (has_valid_field_value(result, "class_start_date") ||
-          has_valid_field_value(result, "class_stop_date")) {
+            has_valid_field_value(result, "class_stop_date")) {
         htmltools::tags$p(
           format_date_range(result$class_start_date, result$class_stop_date)
         )
@@ -99,7 +99,7 @@ create_comm_class_details_ui <- function(result) {
         htmltools::tags$td(
           class = "text-end",
           if (has_valid_field_value(result, "class_publication_rf_code") &&
-            has_valid_field_value(result, "class_publication_rf_label")) {
+                has_valid_field_value(result, "class_publication_rf_label")) {
             create_detail_link(
               "ref_link_click",
               result$class_publication_rf_code,
@@ -126,7 +126,6 @@ create_comm_class_details_ui <- function(result) {
       style = "width: 100%; table-layout: fixed; word-break: break-word;",
       htmltools::tags$tbody(rows)
     )
-
   })
 }
 
@@ -207,7 +206,7 @@ create_comm_class_interpretations_ui <- function(result) {
                   htmltools::tags$td(class = "text-end", typal_value)
                 ),
                 if ("nomenclatural_type" %in% names(interp) &&
-                  has_valid_field_value(interp, "nomenclatural_type")) {
+                      has_valid_field_value(interp, "nomenclatural_type")) {
                   htmltools::tags$tr(
                     htmltools::tags$td("Nomenclatural Type"),
                     htmltools::tags$td(class = "text-end", format_boolean(interp$nomenclatural_type))

--- a/R/detail_plot.R
+++ b/R/detail_plot.R
@@ -246,7 +246,7 @@ build_plot_obs_details_view <- function(result) {
           htmltools::tags$p(format_date_range(plot_observation$obs_start_date, plot_observation$obs_end_date))
         },
         if (has_valid_field_value(plot_observation, "rf_code") &&
-          has_valid_field_value(plot_observation, "rf_label")) {
+              has_valid_field_value(plot_observation, "rf_label")) {
           htmltools::tags$p(
             htmltools::tags$span("Reference: "),
             create_detail_link("ref_link_click", plot_observation$rf_code, plot_observation$rf_label)

--- a/R/detail_plot.R
+++ b/R/detail_plot.R
@@ -165,6 +165,19 @@ build_plot_obs_details_view <- function(result) {
     plot_observation$cover_method_display <- NA_character_
   }
 
+  # Stratum method display (link or fallback) for methods_details card
+  # Must use list() to wrap HTML tag objects for tibble compatibility
+  if (has_valid_field_value(plot_observation, "sm_code") &&
+        has_valid_field_value(plot_observation, "stratum_method_name")) {
+    plot_observation$stratum_method_display <- list(create_detail_link(
+      "stratum_method_link_click",
+      plot_observation$sm_code,
+      plot_observation$stratum_method_name
+    ))
+  } else {
+    plot_observation$stratum_method_display <- NA_character_
+  }
+
   taxa_details_ui <- shiny::renderUI({
     tryCatch(
       {
@@ -306,7 +319,7 @@ build_plot_obs_details_view <- function(result) {
     methods_details = render_detail_table(
       c(
         "method_narrative", "placement_method", "cover_method_display", "cover_dispersion",
-        "stratum_method_name", "stem_sample_method", "stem_observation_area", "stem_size_limit",
+        "stratum_method_display", "stem_sample_method", "stem_observation_area", "stem_size_limit",
         "taxon_observation_area", "auto_taxon_cover"
       ),
       plot_observation,

--- a/R/detail_stratum_method.R
+++ b/R/detail_stratum_method.R
@@ -71,60 +71,21 @@ build_stratum_method_details_view <- function(result) {
       htmltools::tags$tr(
         htmltools::tags$td(st$stratum_index %|||% ""),
         htmltools::tags$td(st$stratum_name %|||% ""),
-        htmltools::tags$td(
-          class = "stratum-type-description",
-          style = "display: none;",
-          st$stratum_description %|||% ""
-        )
+        htmltools::tags$td(st$stratum_description %|||% "")
       )
     })
 
     htmltools::tagList(
-      # JavaScript to handle toggle functionality
-      htmltools::tags$script(htmltools::HTML(
-        "(function() {",
-        "  function toggleStratumTypeDescription() {",
-        "    var descCells = document.querySelectorAll('.stratum-type-description, .stratum-type-description-header');",
-        "    descCells.forEach(function(cell) {",
-        "      cell.style.display = cell.style.display === 'none' ? '' : 'none';",
-        "    });",
-        "  }",
-        "  function initToggle() {",
-        "    var checkbox = document.getElementById('toggle_stratum_type_description');",
-        "    if (checkbox) {",
-        "      checkbox.addEventListener('click', toggleStratumTypeDescription);",
-        "    }",
-        "  }",
-        "  if (document.readyState !== 'loading') {",
-        "    initToggle();",
-        "  } else {",
-        "    document.addEventListener('DOMContentLoaded', initToggle);",
-        "  }",
-        "})();"
-      )),
-      # Toggle for description column
-      htmltools::tags$div(
-        style = "margin-bottom: 10px;",
-        htmltools::tags$label(style = "display: flex; align-items: center;",
-          htmltools::tags$input(
-            type = "checkbox",
-            id = "toggle_stratum_type_description",
-          ),
-          htmltools::tags$span(" Show Stratum Description Column", style = "margin-left: 5px;")
-        )
-      ),
+
+
       htmltools::tags$table(
         class = "table table-sm table-striped table-hover",
-        style = "width: 100%; table-layout: auto; word-break: break-word; white-space: normal;",
+        style = "width: 100%; table-layout: fixed; word-break: break-word; white-space: normal;",
         htmltools::tags$thead(
           htmltools::tags$tr(
-            htmltools::tags$th("Stratum Index"),
-            htmltools::tags$th("Stratum Name"),
-            htmltools::tags$th(
-              class = "stratum-type-description-header",
-              style = "display: none;",
-              "Stratum Description"
-            )
+            htmltools::tags$th(style = "width: 25%;", "Stratum Index"),
+            htmltools::tags$th(style = "width: 35%;", "Stratum Name"),
+            htmltools::tags$th(style = "width: 40%;", "Stratum Description")
           )
         ),
         htmltools::tags$tbody(rows)

--- a/R/detail_stratum_method.R
+++ b/R/detail_stratum_method.R
@@ -1,0 +1,140 @@
+#' Build Stratum Method Details View
+#'
+#' Constructs the complete detail view for a stratum method, including overview and
+#' detail sections. Handles NULL or empty results gracefully by returning empty UI elements.
+#'
+#' @param result A dataframe containing stratum method data from vegbankr::vb_get_stratum_methods()
+#' @return A named list with three shiny.render.function elements:
+#'         stratum_method_header, stratum_method_details, and stratum_types
+#' @noRd
+build_stratum_method_details_view <- function(result) {
+  if (is.null(result) || nrow(result) == 0) {
+    return(create_empty_detail_view(
+      c("stratum_method_header", "stratum_method_details", "stratum_types"),
+      "Stratum method details"
+    ))
+  }
+
+  sm <- result[1, , drop = FALSE]
+
+  # Overview Card - sm_code and stratum_method_name
+  header_ui <- shiny::renderUI({
+    sm_code <- sm$sm_code %|||% "Not recorded"
+    stratum_method_name <- sm$stratum_method_name %|||% "Not recorded"
+
+    htmltools::tags$div(
+      htmltools::tags$h5(stratum_method_name, style = "font-weight: 600; margin-bottom: 0px;"),
+      htmltools::tags$h5(sm_code, style = "color: var(--vegbank-green); font-weight: 600;")
+    )
+  })
+
+  # Detail Card - stratum_method_description, stratum_assignment, and reference link
+  details_ui <- shiny::renderUI({
+    stratum_method_description <- sm$stratum_method_description %|||% "Not recorded"
+    stratum_assignment <- sm$stratum_assignment %|||% "Not recorded"
+
+    # Create reference link if rf_code and rf_label exist
+    reference_display <- if (has_valid_field_value(sm, "rf_code") &&
+      has_valid_field_value(sm, "rf_label")) {
+      create_detail_link("ref_link_click", sm$rf_code, sm$rf_label)
+    } else {
+      "Not provided"
+    }
+
+    details <- list(
+      stratum_method_description = stratum_method_description,
+      stratum_assignment = stratum_assignment,
+      reference = reference_display
+    )
+
+    col_names <- c(
+      stratum_method_description = "Stratum Method Description",
+      stratum_assignment = "Stratum Assignment",
+      reference = "Reference"
+    )
+
+    create_detail_table(details, col_names = col_names)
+  })
+
+  # Stratum Types Card - render table of stratum types
+  types_ui <- shiny::renderUI({
+    # Extract nested stratum_types
+    stratum_types <- extract_nested_table(sm, "stratum_types")
+
+    if (is.null(stratum_types) || nrow(stratum_types) == 0) {
+      return(htmltools::tags$p("No stratum types recorded"))
+    }
+
+    # Build table rows
+    rows <- lapply(seq_len(nrow(stratum_types)), function(i) {
+      st <- stratum_types[i, ]
+      htmltools::tags$tr(
+        htmltools::tags$td(st$stratum_index %|||% ""),
+        htmltools::tags$td(st$stratum_name %|||% ""),
+        htmltools::tags$td(
+          class = "stratum-type-description",
+          style = "display: none;",
+          st$stratum_description %|||% ""
+        )
+      )
+    })
+
+    htmltools::tagList(
+      # JavaScript to handle toggle functionality
+      htmltools::tags$script(htmltools::HTML(
+        "(function() {",
+        "  function toggleStratumTypeDescription() {",
+        "    var descCells = document.querySelectorAll('.stratum-type-description, .stratum-type-description-header');",
+        "    descCells.forEach(function(cell) {",
+        "      cell.style.display = cell.style.display === 'none' ? '' : 'none';",
+        "    });",
+        "  }",
+        "  function initToggle() {",
+        "    var checkbox = document.getElementById('toggle_stratum_type_description');",
+        "    if (checkbox) {",
+        "      checkbox.addEventListener('click', toggleStratumTypeDescription);",
+        "    }",
+        "  }",
+        "  if (document.readyState !== 'loading') {",
+        "    initToggle();",
+        "  } else {",
+        "    document.addEventListener('DOMContentLoaded', initToggle);",
+        "  }",
+        "})();"
+      )),
+      # Toggle for description column
+      htmltools::tags$div(
+        style = "margin-bottom: 10px;",
+        htmltools::tags$label(style = "display: flex; align-items: center;",
+          htmltools::tags$input(
+            type = "checkbox",
+            id = "toggle_stratum_type_description",
+          ),
+          htmltools::tags$span(" Show Stratum Description Column", style = "margin-left: 5px;")
+        )
+      ),
+      htmltools::tags$table(
+        class = "table table-sm table-striped table-hover",
+        style = "width: 100%; table-layout: auto; word-break: break-word; white-space: normal;",
+        htmltools::tags$thead(
+          htmltools::tags$tr(
+            htmltools::tags$th("Stratum Index"),
+            htmltools::tags$th("Stratum Name"),
+            htmltools::tags$th(
+              class = "stratum-type-description-header",
+              style = "display: none;",
+              "Stratum Description"
+            )
+          )
+        ),
+        htmltools::tags$tbody(rows)
+      )
+    )
+  })
+
+  list(
+    stratum_method_header = header_ui,
+    stratum_method_details = details_ui,
+    stratum_types = types_ui
+  )
+}

--- a/R/detail_stratum_method.R
+++ b/R/detail_stratum_method.R
@@ -76,8 +76,6 @@ build_stratum_method_details_view <- function(result) {
     })
 
     htmltools::tagList(
-
-
       htmltools::tags$table(
         class = "table table-sm table-striped table-hover",
         style = "width: 100%; table-layout: fixed; word-break: break-word; white-space: normal;",

--- a/R/detail_view.R
+++ b/R/detail_view.R
@@ -40,7 +40,9 @@ show_detail_view <- function(resource_type, vb_code, output, session) {
         "reference" =
           vegbankr::vb_get_references(vb_code, detail = "full"),
         "cover-method" =
-          vegbankr::vb_get_cover_methods(vb_code, detail = "full", with_nested = TRUE)
+          vegbankr::vb_get_cover_methods(vb_code, detail = "full", with_nested = TRUE),
+        "stratum-method" =
+          vegbankr::vb_get_stratum_methods(vb_code, detail = "full", with_nested = TRUE)
       )
 
       if (length(result) == 0) {
@@ -96,6 +98,9 @@ show_detail_view <- function(resource_type, vb_code, output, session) {
       output$cover_method_header <- shiny::renderUI(NULL)
       output$cover_method_details <- shiny::renderUI(NULL)
       output$cover_method_indexes <- shiny::renderUI(NULL)
+      output$stratum_method_header <- shiny::renderUI(NULL)
+      output$stratum_method_details <- shiny::renderUI(NULL)
+      output$stratum_types <- shiny::renderUI(NULL)
 
       shiny::incProgress(0.5, "Processing details")
 
@@ -160,6 +165,12 @@ show_detail_view <- function(resource_type, vb_code, output, session) {
           output$cover_method_header <- details$cover_method_header
           output$cover_method_details <- details$cover_method_details
           output$cover_method_indexes <- details$cover_method_indexes
+        },
+        "stratum-method" = {
+          details <- build_stratum_method_details_view(result)
+          output$stratum_method_header <- details$stratum_method_header
+          output$stratum_method_details <- details$stratum_method_details
+          output$stratum_types <- details$stratum_types
         }
       )
 

--- a/R/map.R
+++ b/R/map.R
@@ -100,9 +100,9 @@ is_invalid_map_data <- function(map_data) {
 #' @noRd
 filter_valid_map_points <- function(map_data) {
   subset(map_data, !is.na(map_data$latitude) &
-    !is.na(map_data$longitude) &
-    is.numeric(map_data$latitude) &
-    is.numeric(map_data$longitude))
+           !is.na(map_data$longitude) &
+           is.numeric(map_data$latitude) &
+           is.numeric(map_data$longitude))
 }
 
 # ---- Error Notifications ----

--- a/R/server.R
+++ b/R/server.R
@@ -1034,6 +1034,11 @@ server <- function(input, output, session) {
     open_detail("cover-method", vb_code)
   })
 
+  shiny::observeEvent(input$stratum_method_link_click, {
+    vb_code <- input$stratum_method_link_click
+    open_detail("stratum-method", vb_code)
+  })
+
   # CROSS-RESOURCE FILTER OBSERVERS ----------------------------------------------------------------
 
   # Generic observer for all obs_count clicks - extracts entity type from vb_code prefix

--- a/R/server.R
+++ b/R/server.R
@@ -494,8 +494,8 @@ server <- function(input, output, session) {
 
         # Only update if different from current state
         if (is.null(current_filter) ||
-          !identical(current_filter$code, new_filter$code) ||
-          !identical(current_filter$type, new_filter$type)) {
+              !identical(current_filter$code, new_filter$code) ||
+              !identical(current_filter$type, new_filter$type)) {
           state$plot_filter(new_filter)
         }
       } else if (!is.null(params$filter_code) || !is.null(params$filter_type)) {
@@ -575,14 +575,6 @@ server <- function(input, output, session) {
       # This ensures that when user navigates to another tab, that table's
       # pagination state is already restored from URL
       for (table_key in names(table_registry)) {
-        table_params_present <- any(vapply(
-          c("_start", "_length", "_order", "_search"),
-          function(suffix) {
-            !is.null(params[[paste0(table_key, suffix)]])
-          },
-          logical(1)
-        ))
-
         table_state_from_query <- url_manager$extract_table_state_from_query(table_key, params)
 
         if (is.null(table_state_from_query) || url_manager$is_default_table_state(table_key, table_state_from_query)) {

--- a/R/table_plot.R
+++ b/R/table_plot.R
@@ -140,15 +140,21 @@ format_plot_action_buttons <- function(ob_codes, author_codes, latitudes, longit
     has_coords <- !is.na(lat) && !is.na(lng)
     # Details button
     detail_btn <- if (!is.null(detail_code) && nzchar(detail_code)) {
-      sprintf('<button type="button" class="btn btn-sm btn-outline-primary dt-shiny-action" data-input-id="plot_link_click" data-value="%s">Details</button>', htmltools::htmlEscape(detail_code, attribute = TRUE))
+      sprintf(
+        '<button type="button" class="btn btn-sm btn-outline-primary dt-shiny-action" data-input-id="plot_link_click" data-value="%s">Details</button>',
+        htmltools::htmlEscape(detail_code, attribute = TRUE))
     } else {
       '<button type="button" class="btn btn-sm btn-outline-primary" disabled>Details</button>'
     }
     # Map button
     map_btn <- if (has_coords) {
       code_attr <- if (!is.null(code) && nzchar(code)) sprintf(' data-code="%s"', htmltools::htmlEscape(code, attribute = TRUE)) else ''
-      sprintf('<button type="button" class="btn btn-sm btn-outline-primary dt-map-action" data-lat="%s" data-lng="%s"%s>Map</button>',
-        htmltools::htmlEscape(lat, attribute = TRUE), htmltools::htmlEscape(lng, attribute = TRUE), code_attr)
+      sprintf(
+        '<button type="button" class="btn btn-sm btn-outline-primary dt-map-action" data-lat="%s" data-lng="%s"%s>Map</button>',
+        htmltools::htmlEscape(lat, attribute = TRUE),
+        htmltools::htmlEscape(lng, attribute = TRUE),
+        code_attr
+      )
     } else {
       '<button type="button" class="btn btn-sm btn-outline-primary" disabled>Map</button>'
     }

--- a/R/ui.R
+++ b/R/ui.R
@@ -871,11 +871,13 @@ ui <- function(req) {
       const plantConceptCards = document.getElementById('plant-concept-details-cards');
       const referenceCards = document.getElementById('reference-details-cards');
       const coverMethodCards = document.getElementById('cover-method-details-cards');
+      const stratumMethodCards = document.getElementById('stratum-method-details-cards');
 
       console.log('Updating detail type to:', type);
 
       if (plotCards && communityConceptCards && communityClassificationCards &&
-          projectCards && partyCards && plantConceptCards && referenceCards && coverMethodCards) {
+          projectCards && partyCards && plantConceptCards && referenceCards && coverMethodCards &&
+          stratumMethodCards) {
         // Hide all card types first
         plotCards.style.display = 'none';
         communityConceptCards.style.display = 'none';
@@ -885,7 +887,8 @@ ui <- function(req) {
         plantConceptCards.style.display = 'none';
         referenceCards.style.display = 'none';
         coverMethodCards.style.display = 'none';
-
+        stratumMethodCards.style.display = 'none';
+        
         // Show the requested type
         if (type === 'plot-observation') {
           console.log('Showing plot details');
@@ -911,6 +914,9 @@ ui <- function(req) {
         } else if (type === 'cover-method') {
           console.log('Showing cover method details');
           coverMethodCards.style.display = 'block';
+        } else if (type === 'stratum-method') {
+          console.log('Showing stratum method details');
+          stratumMethodCards.style.display = 'block';
         }
       }
     });
@@ -1236,6 +1242,15 @@ build_detail_overlay <- function() {
           bslib::card(bslib::card_header("Cover Method"), shiny::uiOutput("cover_method_header")),
           bslib::card(bslib::card_header("Details"), shiny::uiOutput("cover_method_details")),
           bslib::card(bslib::card_header("Cover Indexes"), shiny::uiOutput("cover_method_indexes"))
+        ),
+
+        # Stratum Method Details Cards - wrapped in a div with class for toggling visibility
+        htmltools::tags$div(
+          id = "stratum-method-details-cards",
+          class = "detail-section",
+          bslib::card(bslib::card_header("Stratum Method"), shiny::uiOutput("stratum_method_header")),
+          bslib::card(bslib::card_header("Details"), shiny::uiOutput("stratum_method_details")),
+          bslib::card(bslib::card_header("Stratum Types"), shiny::uiOutput("stratum_types"))
         )
       )
     )

--- a/R/ui.R
+++ b/R/ui.R
@@ -888,7 +888,7 @@ ui <- function(req) {
         referenceCards.style.display = 'none';
         coverMethodCards.style.display = 'none';
         stratumMethodCards.style.display = 'none';
-        
+
         // Show the requested type
         if (type === 'plot-observation') {
           console.log('Showing plot details');

--- a/R/url_state_manager.R
+++ b/R/url_state_manager.R
@@ -353,7 +353,7 @@ URLStateManager <- R6::R6Class(
       params$tab <- tab
 
       if (!is.null(detail_type) && !is.null(detail_code) &&
-        nzchar(detail_type) && nzchar(detail_code)) {
+            nzchar(detail_type) && nzchar(detail_code)) {
         params$detail <- detail_type
         params$code <- detail_code
 

--- a/inst/shiny/www/display_name_lookup.txt
+++ b/inst/shiny/www/display_name_lookup.txt
@@ -550,6 +550,7 @@ stratumindex,stratum_index,Stratum Index
 stratummethod_id,stratum_method_id,Stratum Method ID
 stratummethodaccessioncode,stratum_method_accession_code,Stratum Method Accession Code
 stratummethoddescription,stratum_method_description,Stratum Method Description
+stratummethoddisplay,stratum_method_display,Stratum Method
 stratummethodname,stratum_method_name,Stratum Method
 stratumname,stratum_name,Stratum Name
 stratumtype_id,stratum_type_id,Stratum Type ID

--- a/tests/testthat/test_detail_stratum_method.R
+++ b/tests/testthat/test_detail_stratum_method.R
@@ -1,0 +1,208 @@
+# Tests for stratum method detail view
+
+# Create mock stratum method data
+mock_stratum_method_with_types <- data.frame(
+  sm_code = "sm.1",
+  stratum_method_name = "Carolina Vegetation Survey",
+  stratum_method_description = "Stratum heights are constructed to reflect the vegetation of the plot.  Foliage is then determined to belong to a stratum based only on height of the foliage, not the individual.  Lifeform is not considered.  An individual's foliage may be broken into different strata.",
+  stratum_assignment = NA,
+  rf_code = "rf.27",
+  rf_label = "CVS Protocol",
+  stringsAsFactors = FALSE
+)
+
+# Add nested stratum_types as a list column
+mock_stratum_method_with_types$stratum_types <- list(data.frame(
+  sy_code = c("sy.1", "sy.2", "sy.3"),
+  stratum_index = c("E", "H", "S"),
+  stratum_name = c("Emergent", "Herb", "Shrub"),
+  stratum_description = c(
+    "Foliage generally greater than 35m high",
+    "Foliage generally less than 0.5m high",
+    "Foliage generally 0.5-6m high"
+  ),
+  stringsAsFactors = FALSE
+))
+
+mock_stratum_method_no_types <- data.frame(
+  sm_code = "sm.999",
+  stratum_method_name = "Test Method",
+  stratum_method_description = NA,
+  stratum_assignment = NA,
+  rf_code = NA,
+  rf_label = NA,
+  stringsAsFactors = FALSE
+)
+
+mock_stratum_method_no_types$stratum_types <- list(data.frame())
+
+test_that("build_stratum_method_details_view handles NULL data gracefully", {
+  result <- build_stratum_method_details_view(NULL)
+
+  expect_type(result, "list")
+  expect_named(result, c(
+    "stratum_method_header",
+    "stratum_method_details",
+    "stratum_types"
+  ))
+
+  expect_s3_class(result$stratum_method_header, "shiny.render.function")
+  mock_session <- shiny::MockShinySession$new()
+  html <- htmltools::renderTags(result$stratum_method_header(shinysession = mock_session))$html
+  expect_true(grepl("Stratum method details not available", html))
+})
+
+test_that("build_stratum_method_details_view handles empty dataframe", {
+  result <- build_stratum_method_details_view(data.frame())
+
+  expect_type(result, "list")
+  expect_named(result, c(
+    "stratum_method_header",
+    "stratum_method_details",
+    "stratum_types"
+  ))
+
+  mock_session <- shiny::MockShinySession$new()
+  html <- htmltools::renderTags(result$stratum_method_header(shinysession = mock_session))$html
+  expect_true(grepl("Stratum method details not available", html))
+})
+
+test_that("build_stratum_method_details_view formats stratum method with types and reference", {
+  details <- build_stratum_method_details_view(mock_stratum_method_with_types)
+
+  expect_type(details, "list")
+  expect_named(details, c(
+    "stratum_method_header",
+    "stratum_method_details",
+    "stratum_types"
+  ))
+
+  expect_s3_class(details$stratum_method_header, "shiny.render.function")
+  expect_s3_class(details$stratum_method_details, "shiny.render.function")
+  expect_s3_class(details$stratum_types, "shiny.render.function")
+
+  mock_session <- shiny::MockShinySession$new()
+
+  # Test header
+  header_html <- htmltools::renderTags(details$stratum_method_header(shinysession = mock_session))$html
+  expect_true(grepl("Carolina Vegetation Survey", header_html))
+  expect_true(grepl("sm.1", header_html))
+
+  # Test details (should have description and reference link)
+  details_html <- htmltools::renderTags(details$stratum_method_details(shinysession = mock_session))$html
+  expect_true(grepl("Stratum heights are constructed", details_html))
+  expect_true(grepl("CVS Protocol", details_html))
+  expect_true(grepl("ref_link_click", details_html))
+  expect_true(grepl("rf.27", details_html))
+
+  # Test stratum types table
+  types_html <- htmltools::renderTags(details$stratum_types(shinysession = mock_session))$html
+  expect_true(grepl("Stratum Index", types_html))
+  expect_true(grepl("Stratum Name", types_html))
+  expect_true(grepl("Stratum Description", types_html))
+  expect_true(grepl("Emergent", types_html))
+  expect_true(grepl("Herb", types_html))
+  expect_true(grepl("Shrub", types_html))
+  expect_true(grepl("greater than 35m high", types_html))
+
+  # Test toggle checkbox
+  expect_true(grepl("toggle_stratum_type_description", types_html))
+  expect_true(grepl("Show Stratum Description Column", types_html))
+})
+
+test_that("build_stratum_method_details_view handles stratum method without reference", {
+  details <- build_stratum_method_details_view(mock_stratum_method_no_types)
+
+  mock_session <- shiny::MockShinySession$new()
+
+  # Test header
+  header_html <- htmltools::renderTags(details$stratum_method_header(shinysession = mock_session))$html
+  expect_true(grepl("Test Method", header_html))
+  expect_true(grepl("sm.999", header_html))
+
+  # Test details (should show "Not provided" for reference)
+  details_html <- htmltools::renderTags(details$stratum_method_details(shinysession = mock_session))$html
+  expect_true(grepl("Not provided", details_html))
+  expect_true(grepl("Not recorded", details_html)) # stratum_method_description is NA
+
+  # Test types (should show no types message)
+  types_html <- htmltools::renderTags(details$stratum_types(shinysession = mock_session))$html
+  expect_true(grepl("No stratum types recorded", types_html))
+})
+
+test_that("build_stratum_method_details_view handles missing fields gracefully", {
+  minimal_data <- data.frame(
+    sm_code = "sm.888",
+    stratum_method_name = NA,
+    stratum_method_description = NA,
+    stratum_assignment = NA,
+    rf_code = NA,
+    rf_label = NA,
+    stringsAsFactors = FALSE
+  )
+  minimal_data$stratum_types <- list(data.frame())
+
+  details <- build_stratum_method_details_view(minimal_data)
+
+  mock_session <- shiny::MockShinySession$new()
+
+  # Test header with missing stratum_method_name
+  header_html <- htmltools::renderTags(details$stratum_method_header(shinysession = mock_session))$html
+  expect_true(grepl("Not recorded", header_html))
+  expect_true(grepl("sm.888", header_html))
+
+  # Test details with all missing fields
+  details_html <- htmltools::renderTags(details$stratum_method_details(shinysession = mock_session))$html
+  expect_true(grepl("Not recorded", details_html))
+  expect_true(grepl("Not provided", details_html))
+})
+
+test_that("build_stratum_method_details_view creates clickable reference link", {
+  details <- build_stratum_method_details_view(mock_stratum_method_with_types)
+
+  mock_session <- shiny::MockShinySession$new()
+  details_html <- htmltools::renderTags(details$stratum_method_details(shinysession = mock_session))$html
+
+  # Verify the reference link has the correct structure (uses onclick with Shiny.setInputValue)
+  expect_true(grepl("Shiny.setInputValue", details_html, fixed = TRUE))
+  expect_true(grepl("ref_link_click", details_html, fixed = TRUE))
+  expect_true(grepl("rf.27", details_html))
+  expect_true(grepl("CVS Protocol", details_html))
+  expect_true(grepl('href="#"', details_html, fixed = TRUE))
+})
+
+test_that("stratum types table has correct column visibility toggle", {
+  details <- build_stratum_method_details_view(mock_stratum_method_with_types)
+
+  mock_session <- shiny::MockShinySession$new()
+  types_html <- htmltools::renderTags(details$stratum_types(shinysession = mock_session))$html
+
+  # Check for toggle checkbox
+  expect_true(grepl('<input type="checkbox"', types_html))
+  expect_true(grepl('id="toggle_stratum_type_description"', types_html))
+
+  # Check that description column and header are hidden by default
+  expect_true(grepl('class="stratum-type-description-header"', types_html))
+  expect_true(grepl('style="display: none;"', types_html))
+})
+
+test_that("stratum types table handles NULL stratum_description gracefully", {
+  stratum_method_null_desc <- mock_stratum_method_with_types
+  stratum_method_null_desc$stratum_types <- list(data.frame(
+    sy_code = c("sy.1", "sy.2"),
+    stratum_index = c("A", "F"),
+    stratum_name = c("Aquatic submerged", "Floating"),
+    stratum_description = c(NA, NA),
+    stringsAsFactors = FALSE
+  ))
+
+  details <- build_stratum_method_details_view(stratum_method_null_desc)
+
+  mock_session <- shiny::MockShinySession$new()
+  types_html <- htmltools::renderTags(details$stratum_types(shinysession = mock_session))$html
+
+  # Table should still render with names
+  expect_true(grepl("Aquatic submerged", types_html))
+  expect_true(grepl("Floating", types_html))
+  expect_true(grepl("Stratum Index", types_html))
+})

--- a/tests/testthat/test_detail_stratum_method.R
+++ b/tests/testthat/test_detail_stratum_method.R
@@ -104,10 +104,6 @@ test_that("build_stratum_method_details_view formats stratum method with types a
   expect_true(grepl("Herb", types_html))
   expect_true(grepl("Shrub", types_html))
   expect_true(grepl("greater than 35m high", types_html))
-
-  # Test toggle checkbox
-  expect_true(grepl("toggle_stratum_type_description", types_html))
-  expect_true(grepl("Show Stratum Description Column", types_html))
 })
 
 test_that("build_stratum_method_details_view handles stratum method without reference", {
@@ -169,21 +165,6 @@ test_that("build_stratum_method_details_view creates clickable reference link", 
   expect_true(grepl("rf.27", details_html))
   expect_true(grepl("CVS Protocol", details_html))
   expect_true(grepl('href="#"', details_html, fixed = TRUE))
-})
-
-test_that("stratum types table has correct column visibility toggle", {
-  details <- build_stratum_method_details_view(mock_stratum_method_with_types)
-
-  mock_session <- shiny::MockShinySession$new()
-  types_html <- htmltools::renderTags(details$stratum_types(shinysession = mock_session))$html
-
-  # Check for toggle checkbox
-  expect_true(grepl('<input type="checkbox"', types_html))
-  expect_true(grepl('id="toggle_stratum_type_description"', types_html))
-
-  # Check that description column and header are hidden by default
-  expect_true(grepl('class="stratum-type-description-header"', types_html))
-  expect_true(grepl('style="display: none;"', types_html))
 })
 
 test_that("stratum types table handles NULL stratum_description gracefully", {


### PR DESCRIPTION
## What:
Closes #57 by creating a detail view for stratum methods accessible from the plot observation details page. It's very similar to the cover method detail view, but doesn't have a toggle for the description column since it mostly fits with the current shape of the data.

## Why:
So that the stratum method details returned by the api can be viewed in the app an users can get more context about plot observation methodology.

## How:

- Updated the lintr rules and some formatting throughout the app
- Updated plot obs details to render a link for the stratum method name
- Created detail_stratum_method.R and the necessary piping to fill in a header, description, and index details when that link is clicked
- Created tests for the stratum method detail view
- Removed the toggle for the description column in the index table since it (mostly) fits

## Testing and documentation:
All 730 tests (including new ones for stratum method detail view) pass and check() only returns the same 3 notes.
