### PR TITLE
Bugfix 134 initial map load

### DIFF
--- a/R/map.R
+++ b/R/map.R
@@ -18,41 +18,39 @@ MAP_DATA_FETCH_LIMIT <- 1000000L
 #' @return Data frame of plot observations or NULL on failure
 #' @noRd
 fetch_plot_map_data <- function(limit = MAP_DATA_FETCH_LIMIT, detail = "geo") {
-  shiny::withProgress(message = "Loading map data...", value = 0.2, {
-    error_occurred <- FALSE
+  error_occurred <- FALSE
 
-    data <- tryCatch(
-      vegbankr::vb_get_plot_observations(
-        limit = limit,
-        detail = detail,
-        with_nested = FALSE
-      ),
-      error = function(err) {
-        error_occurred <<- TRUE
-        shiny::showNotification(
-          paste("Failed to load map data:", conditionMessage(err)),
-          type = "error"
-        )
-        NULL
-      }
-    )
-
-    shiny::incProgress(1)
-
-    if (isTRUE(error_occurred)) {
-      return(NULL)
-    }
-
-    if (is.null(data) || nrow(data) == 0) {
+  data <- tryCatch(
+    vegbankr::vb_get_plot_observations(
+      limit = limit,
+      detail = detail,
+      with_nested = FALSE
+    ),
+    error = function(err) {
+      error_occurred <<- TRUE
       shiny::showNotification(
-        "Map data is currently unavailable. Please try again later.",
-        type = "warning"
+        paste("Failed to load map data:", conditionMessage(err)),
+        type = "error",
+        duration = NULL
       )
-      return(NULL)
+      NULL
     }
+  )
 
-    as.data.frame(data)
-  })
+  if (isTRUE(error_occurred)) {
+    return(NULL)
+  }
+
+  if (is.null(data) || nrow(data) == 0) {
+    shiny::showNotification(
+      "Map data is currently unavailable. Please try again later.",
+      type = "warning",
+      duration = NULL
+    )
+    return(NULL)
+  }
+
+  as.data.frame(data)
 }
 
 # ---- Data Validation ----
@@ -155,17 +153,9 @@ process_map_data <- function(map_data, center_lng, center_lat, zoom, map_options
     return(create_empty_map(map_defaults, center_lng, center_lat, zoom))
   }
 
-  # Step 2: Build map with progress indicator
-  shiny::withProgress(message = "Building map...", value = 0, {
-    shiny::incProgress(0.3, detail = "Grouping plots by location...")
-    data_grouped <- group_map_points(validation$data)
-
-    shiny::incProgress(0.5, detail = "Rendering map...")
-    result <- build_leaflet_map(data_grouped, map_defaults, center_lng, center_lat, zoom)
-
-    shiny::incProgress(0.2)
-    result
-  })
+  # Step 2: Build map (progress is shown via custom loading screen)
+  data_grouped <- group_map_points(validation$data)
+  build_leaflet_map(data_grouped, map_defaults, center_lng, center_lat, zoom)
 }
 
 #' Move the map and show a popup at a given location

--- a/R/server.R
+++ b/R/server.R
@@ -72,6 +72,7 @@ server <- function(input, output, session) {
   # Map data state: observations for the leaflet map and fetch status flag
   map_observations <- shiny::reactiveVal(NULL)
   map_fetch_in_progress <- shiny::reactiveVal(FALSE)
+  map_initialized <- shiny::reactiveVal(FALSE)
 
   # Initialize URL State Manager with defaults and table registry
   url_manager <- URLStateManager$new(
@@ -131,6 +132,13 @@ server <- function(input, output, session) {
         return()
       }
 
+      # Check if map has been initialized before
+      if (!isTRUE(map_initialized())) {
+        # First time loading - show loading screen and lock nav
+        session$sendCustomMessage("showMapLoading", list())
+        session$sendCustomMessage("setNavInteractivity", list(disabled = TRUE))
+      }
+
       # Fetch data
       map_fetch_in_progress(TRUE)
       observations <- fetch_plot_map_data()
@@ -138,6 +146,12 @@ server <- function(input, output, session) {
 
       if (!is.null(observations)) {
         map_observations(observations)
+        # Note: map_initialized flag and loading screen will be hidden
+        # by the onRender callback in output$map after map fully renders
+      } else {
+        # If data fetch failed, still unlock nav and hide loading screen
+        session$sendCustomMessage("setNavInteractivity", list(disabled = FALSE))
+        session$sendCustomMessage("hideMapLoading", list())
       }
     },
     ignoreInit = TRUE
@@ -806,16 +820,104 @@ server <- function(input, output, session) {
     # Wait for map data to be available (fetched when Map tab is visited)
     shiny::req(map_observations())
 
-    process_map_data(
+    map <- process_map_data(
       map_data = map_observations(),
       center_lng = DEFAULT_MAP_LNG,
       center_lat = DEFAULT_MAP_LAT,
       zoom = DEFAULT_MAP_ZOOM
     )
+    
+    # Add callback to hide loading screen once map is fully rendered
+    # Use isolate() to prevent creating a reactive dependency on map_initialized()
+    if (!isTRUE(shiny::isolate(map_initialized()))) {
+      map <- htmlwidgets::onRender(map, "
+        function(el, x) {
+          var map = this;
+          var signaled = false;
+          
+          function signalMapReady() {
+            if (!signaled) {
+              signaled = true;
+              Shiny.setInputValue('map_ready', true, {priority: 'event'});
+            }
+          }
+          
+          // Check if all visible tile images have full opacity
+          function allTilesFullOpacity() {
+            var tiles = el.querySelectorAll('.leaflet-tile-loaded');
+            if (tiles.length === 0) return false;
+            
+            for (var i = 0; i < tiles.length; i++) {
+              var style = window.getComputedStyle(tiles[i]);
+              var opacity = parseFloat(style.opacity);
+              if (opacity < 0.99) {
+                return false;
+              }
+            }
+            return true;
+          }
+          
+          // Check if map container is NOT recalculating (Shiny output state)
+          function isNotRecalculating() {
+            return !el.classList.contains('recalculating');
+          }
+          
+          // Check if clusters are rendered
+          function hasClusters() {
+            var clusters = el.querySelectorAll('.marker-cluster');
+            var markers = el.querySelectorAll('.leaflet-marker-icon');
+            return clusters.length > 0 || markers.length > 0;
+          }
+          
+          // Main readiness check - polls until all conditions are met
+          function checkFullyReady() {
+            if (signaled) return;
+            
+            var notRecalculating = isNotRecalculating();
+            var tilesReady = allTilesFullOpacity();
+            var clustersPresent = hasClusters();
+            
+            if (notRecalculating && tilesReady && clustersPresent) {
+              signalMapReady();
+            } else {
+              // Keep checking every 50ms
+              setTimeout(checkFullyReady, 50);
+            }
+          }
+          
+          // Start checking after initial render
+          map.whenReady(function() {
+            // Give Leaflet a moment to start tile loading
+            setTimeout(checkFullyReady, 100);
+          });
+          
+          // Fallback timeout
+          setTimeout(function() {
+            if (!signaled) {
+              signalMapReady();
+            }
+          }, 15000);
+        }
+      ")
+    }
+    
+    map
   })
 
 
   # EVENT OBSERVERS --------------------------------------------------------------------------------
+
+  # Hide loading screen when map is fully rendered and ready
+  shiny::observeEvent(input$map_ready,
+    {
+      if (!isTRUE(map_initialized())) {
+        map_initialized(TRUE)
+        session$sendCustomMessage("hideMapLoading", list())
+        session$sendCustomMessage("setNavInteractivity", list(disabled = FALSE))
+      }
+    },
+    ignoreInit = TRUE
+  )
 
   # Track map state changes without triggering redraws
   shiny::observeEvent(input$map_zoom,

--- a/R/server.R
+++ b/R/server.R
@@ -907,7 +907,7 @@ server <- function(input, output, session) {
 
   # EVENT OBSERVERS --------------------------------------------------------------------------------
 
-  # Invalidatoing the map size is necessary when navigating to Map tab because the map fogets its size when
+  # Invalidating the map size is necessary when navigating to Map tab because the map forgets its size when
   # hidden and needs to be recalculated to render properly. See https://github.com/NCEAS/vegbank-web/issues/28
   shiny::observeEvent(input$page,
     {
@@ -1085,8 +1085,8 @@ server <- function(input, output, session) {
 
         map_req <- state$map_request()
         if (!is.null(map_req)) {
-          # Invalidatoing the map size is necessary when navigating to Map tab because the
-          # map fogets its size when hidden and needs to be recalculated to render properly.
+          # Invalidating the map size is necessary when navigating to Map tab because the
+          # map fogrets its size when hidden and needs to be recalculated to render properly.
           # See https://github.com/NCEAS/vegbank-web/issues/28
           session$sendCustomMessage("invalidateMapSize", list())
           move_map_to_obs(

--- a/R/server.R
+++ b/R/server.R
@@ -907,6 +907,18 @@ server <- function(input, output, session) {
 
   # EVENT OBSERVERS --------------------------------------------------------------------------------
 
+  # Invalidatoing the map size is necessary when navigating to Map tab because the map fogets its size when
+  # hidden and needs to be recalculated to render properly. See https://github.com/NCEAS/vegbank-web/issues/28
+  shiny::observeEvent(input$page,
+    {
+      if (identical(input$page, "Map")) {
+        # Invalidate map size to ensure proper rendering after tab switches
+        session$sendCustomMessage("invalidateMapSize", list())
+      }
+    },
+    ignoreInit = TRUE
+  )
+
   # Hide loading screen when map is fully rendered and ready
   shiny::observeEvent(input$map_ready,
     {
@@ -1073,6 +1085,9 @@ server <- function(input, output, session) {
 
         map_req <- state$map_request()
         if (!is.null(map_req)) {
+          # Invalidatoing the map size is necessary when navigating to Map tab because the
+          # map fogets its size when hidden and needs to be recalculated to render properly.
+          # See https://github.com/NCEAS/vegbank-web/issues/28
           session$sendCustomMessage("invalidateMapSize", list())
           move_map_to_obs(
             session,

--- a/R/table.R
+++ b/R/table.R
@@ -360,7 +360,7 @@ extract_reported_total <- function(details) {
 #' @param table_id Output ID of the DT widget
 #' @param resource VegBank (or other API) resource type used for remote data
 #' @param data_key Name of the data source entry used inside processing helpers
-#' @param remote_label Friendly label for progress/loading messages
+#' @param loading_label Friendly label for progress/loading messages
 #' @param fields Character vector describing the canonical data schema
 #' @param extra Named list merged into the base entry for module-specific values
 #' @returns A list entry that can be stored inside a table config map
@@ -369,7 +369,7 @@ build_table_module_config <- function(type,
                                       table_id,
                                       resource,
                                       data_key,
-                                      remote_label,
+                                      loading_label,
                                       fields,
                                       extra = list()) {
   base <- list(
@@ -377,7 +377,7 @@ build_table_module_config <- function(type,
     table_id = table_id,
     resource = resource,
     data_key = data_key,
-    remote_label = remote_label,
+    loading_label = loading_label,
     fields = fields
   )
 
@@ -580,7 +580,7 @@ build_remote_ajax_config <- function(session,
 #'   `page_length`, `coerce_fn`, `normalize_fn`, `display_fn`, `empty_factory`,
 #'   `detail`, `parquet`, `clean_names`, `search_normalizer`, `clean_rows_fn`,
 #'   `count_*` overrides, `query`, `count_query`, or a custom `ajax_factory`.
-#' @param remote_label Human-friendly label used in progress/processing messages
+#' @param loading_label Human-friendly label used in progress/processing messages
 #' @param page_length Page length override (defaults to TABLE_PAGE_LENGTH)
 #' @param options Additional DataTables option overrides merged onto the remote
 #'   defaults (`serverSide`, `lengthChange`, etc.)
@@ -591,7 +591,7 @@ build_remote_ajax_config <- function(session,
 build_remote_table_config <- function(column_defs,
                                       initial_data,
                                       data_source_spec,
-                                      remote_label = NULL,
+                                      loading_label = NULL,
                                       page_length = NULL,
                                       options = list(),
                                       datatable_args = list()) {
@@ -605,12 +605,12 @@ build_remote_table_config <- function(column_defs,
     stop("data_source_spec$resource is required")
   }
 
-  remote_label <- remote_label %||% data_source_spec$label %||% "data"
+  loading_label <- loading_label %||% data_source_spec$label %||% "data"
   effective_page_length <- page_length %||% data_source_spec$page_length %||% TABLE_PAGE_LENGTH
   data_source_spec$page_length <- effective_page_length
 
-  processing_label <- if (!is.null(remote_label)) {
-    paste0("Loading ", remote_label, "...")
+  processing_label <- if (!is.null(loading_label)) {
+    paste0("Loading ", loading_label, "...")
   } else {
     "Loading data..."
   }
@@ -636,7 +636,7 @@ build_remote_table_config <- function(column_defs,
     column_defs = column_defs,
     page_length = effective_page_length,
     use_progress = FALSE,
-    progress_message = paste0("Processing ", remote_label, " table data"),
+    progress_message = paste0("Processing ", loading_label, " table data"),
     initial_data = initial_data %||% data.frame(),
     options = utils::modifyList(remote_defaults, options),
     datatable_args = datatable_args,
@@ -733,7 +733,7 @@ build_display_template <- function(column_names, column_types = NULL) {
 #' @noRd
 build_table_config_from_spec <- function(spec) {
   required_fields <- c(
-    "table_id", "resource", "remote_label", "column_defs",
+    "table_id", "resource", "loading_label", "column_defs",
     "schema_fields", "coerce_fn", "normalize_fn", "display_fn"
   )
   missing <- required_fields[vapply(required_fields, function(field) is.null(spec[[field]]), logical(1))]
@@ -754,7 +754,7 @@ build_table_config_from_spec <- function(spec) {
       coerce_fn = spec$coerce_fn,
       normalize_fn = spec$normalize_fn,
       display_fn = spec$display_fn,
-      label = spec$remote_label,
+      label = spec$loading_label,
       schema_fields = spec$schema_fields,
       empty_factory = function() schema_template
     ),
@@ -767,7 +767,7 @@ build_table_config_from_spec <- function(spec) {
     column_defs = spec$column_defs,
     initial_data = initial_display,
     data_source_spec = data_source_spec,
-    remote_label = spec$remote_label,
+    loading_label = spec$loading_label,
     page_length = spec$page_length,
     options = spec$options %||% list(),
     datatable_args = spec$datatable_args

--- a/R/table_concept.R
+++ b/R/table_concept.R
@@ -8,7 +8,7 @@ CONCEPT_CONFIG <- list(
     table_id = "plant_table",
     resource = "plant-concepts",
     data_key = "plant_data",
-    remote_label = "plant concepts",
+    loading_label = "plant concepts",
     fields = c(
       "pc_code",
       "plant_name",
@@ -33,7 +33,7 @@ CONCEPT_CONFIG <- list(
     table_id = "comm_table",
     resource = "community-concepts",
     data_key = "community_data",
-    remote_label = "community concepts",
+    loading_label = "community concepts",
     fields = c(
       "cc_code",
       "comm_name",
@@ -237,7 +237,7 @@ CONCEPT_TABLE_SPECS <- local({
     list(
       table_id = config$table_id,
       resource = config$resource,
-      remote_label = config$remote_label,
+      loading_label = config$loading_label,
       column_defs = create_concept_column_defs(link_input_id),
       schema_fields = config$fields,
       schema_template = schema_template,

--- a/R/table_party.R
+++ b/R/table_party.R
@@ -99,7 +99,7 @@ coerce_party_page <- create_coercer(PARTY_TABLE_SCHEMA_TEMPLATE)
 PARTY_TABLE_SPEC <- list(
   table_id = "party_table",
   resource = "parties",
-  remote_label = "party records",
+  remote_label = "parties",
   column_defs = create_party_column_defs(),
   schema_fields = PARTY_TABLE_FIELDS,
   schema_template = PARTY_TABLE_SCHEMA_TEMPLATE,

--- a/R/table_party.R
+++ b/R/table_party.R
@@ -99,7 +99,7 @@ coerce_party_page <- create_coercer(PARTY_TABLE_SCHEMA_TEMPLATE)
 PARTY_TABLE_SPEC <- list(
   table_id = "party_table",
   resource = "parties",
-  remote_label = "parties",
+  loading_label = "parties",
   column_defs = create_party_column_defs(),
   schema_fields = PARTY_TABLE_FIELDS,
   schema_template = PARTY_TABLE_SCHEMA_TEMPLATE,

--- a/R/table_plot.R
+++ b/R/table_plot.R
@@ -413,7 +413,7 @@ coerce_plot_page <- create_coercer(PLOT_TABLE_SCHEMA_TEMPLATE)
 PLOT_TABLE_SPEC <- list(
   table_id = "plot_table",
   resource = "plot-observations",
-  remote_label = "plot observations",
+  loading_label = "plot observations",
   column_defs = create_plot_column_defs(),
   schema_fields = PLOT_TABLE_FIELDS,
   schema_template = PLOT_TABLE_SCHEMA_TEMPLATE,

--- a/R/table_plot.R
+++ b/R/table_plot.R
@@ -78,10 +78,18 @@ build_plot_table_with_filter <- function(vb_code = NULL) {
   spec$data_source <- utils::modifyList(spec$data_source, list())
   spec$data_source$query <- as.list(spec$data_source$query)
 
+  # Determine if filter is active
+  has_filter <- !is.null(vb_code) && !is.na(vb_code) && nzchar(vb_code)
+
   # Add vb_code to query if filtering is active
-  if (!is.null(vb_code) && !is.na(vb_code) && nzchar(vb_code)) {
+  if (has_filter) {
     spec$data_source$query$vb_code <- vb_code
   }
+
+  spec$options <- utils::modifyList(spec$options, list())
+
+  # Adjust table height based on whether filter alert is shown so we don't overflow viewport
+  spec$options$scrollY <- if (has_filter) "calc(100vh - 315px)" else "calc(100vh - 235px)"
 
   build_table_from_spec(spec)
 }
@@ -423,7 +431,9 @@ PLOT_TABLE_SPEC <- list(
     )
   ),
   page_length = NULL,
-  options = list(),
+  options = list(
+    scrollY = "calc(100vh - 235px)"
+  ),
   datatable_args = list(),
   initial_display = PLOT_TABLE_DISPLAY_TEMPLATE
 )

--- a/R/table_project.R
+++ b/R/table_project.R
@@ -110,7 +110,7 @@ coerce_project_page <- create_coercer(PROJECT_TABLE_SCHEMA_TEMPLATE)
 PROJECT_TABLE_SPEC <- list(
   table_id = "proj_table",
   resource = "projects",
-  remote_label = "projects",
+  loading_label = "projects",
   column_defs = create_project_column_defs(),
   schema_fields = PROJECT_TABLE_FIELDS,
   schema_template = PROJECT_TABLE_SCHEMA_TEMPLATE,

--- a/R/table_project.R
+++ b/R/table_project.R
@@ -110,7 +110,7 @@ coerce_project_page <- create_coercer(PROJECT_TABLE_SCHEMA_TEMPLATE)
 PROJECT_TABLE_SPEC <- list(
   table_id = "proj_table",
   resource = "projects",
-  remote_label = "project records",
+  remote_label = "projects",
   column_defs = create_project_column_defs(),
   schema_fields = PROJECT_TABLE_FIELDS,
   schema_template = PROJECT_TABLE_SCHEMA_TEMPLATE,

--- a/R/ui.R
+++ b/R/ui.R
@@ -1222,7 +1222,8 @@ build_navbar <- function() {
 build_detail_overlay <- function() {
   htmltools::tags$div(
     id = "detail-overlay",
-    style = "position: fixed; top: 0; right: -400px; width: 400px; height: 100vh; overflow-y: auto;
+    style = "position: fixed; top: var(--bslib-navbar-height, 57px); right: -400px; width: 400px; 
+             height: calc(100vh - var(--bslib-navbar-height, 57px)); overflow-y: auto;
              background: #fff; border-left: 1px solid #ccc; z-index: 1050; padding:20px;
              transition: right 0.4s;",
     shiny::actionButton("close_overlay", "",
@@ -1344,7 +1345,7 @@ build_map_loading_overlay <- function() {
     id = "map-loading-overlay",
     style = "display: none; position: fixed; top: var(--bslib-navbar-height, 58px); left: 0; 
              width: 100vw; height: calc(100vh - var(--bslib-navbar-height, 58px));
-             background: rgba(255, 255, 255, 0.98); z-index: 900;
+             background: rgba(255, 255, 255, 0.98); z-index: 1200;
              justify-content: center; align-items: center; flex-direction: column;",
     htmltools::tags$div(
       class = "map-loading-content",

--- a/R/ui.R
+++ b/R/ui.R
@@ -1342,12 +1342,17 @@ build_detail_overlay <- function() {
 build_map_loading_overlay <- function() {
   htmltools::tags$div(
     id = "map-loading-overlay",
-    style = "display: none; position: fixed; top: 0; left: 0; width: 100vw; height: 100vh;
-             background: rgba(255, 255, 255, 0.98); z-index: 9999;
+    style = "display: none; position: fixed; top: var(--bslib-navbar-height, 58px); left: 0; 
+             width: 100vw; height: calc(100vh - var(--bslib-navbar-height, 58px));
+             background: rgba(255, 255, 255, 0.98); z-index: 900;
              justify-content: center; align-items: center; flex-direction: column;",
     htmltools::tags$div(
       class = "map-loading-content",
       style = "text-align: center;",
+      htmltools::tags$h2(
+        "Loading the Map for the first time can take a few seconds. It's busy:",
+        style = "font-size: 1rem; color: var(--no-status-text); font-weight: 500; margin-bottom: 1.5rem;"
+      ),
       htmltools::tags$div(
         class = "map-loading-spinner",
         style = "width: 80px; height: 80px; margin: 0 auto 2rem auto;

--- a/R/ui.R
+++ b/R/ui.R
@@ -19,7 +19,7 @@ ui <- function(req) {
     htmltools::tags$link(rel = "stylesheet", href = "https://rsms.me/inter/inter.css")
   )
 
-  navbar_with_search <- build_navbar()
+  navbar <- build_navbar()
   overlay <- build_detail_overlay()
   map_loading_overlay <- build_map_loading_overlay()
 
@@ -982,7 +982,7 @@ ui <- function(req) {
   "
   ))
 
-  htmltools::tagList(font_head, navbar_with_search, overlay, map_loading_overlay, script)
+  htmltools::tagList(font_head, navbar, overlay, map_loading_overlay, script)
 }
 
 #' Custom Bootstrap Theme for Vegbank Web Application

--- a/R/ui.R
+++ b/R/ui.R
@@ -1009,6 +1009,8 @@ custom_theme <- bslib::bs_add_rules(
     font-feature-settings: 'liga' 1, 'calt' 1;
     --bs-font-sans-serif: Inter, sans-serif !important;
 
+    --bslib-navbar-height: 57px;
+
     /* Vegbank brand colors */
     --vb-green: hsl(153, 31%, 25%);
 
@@ -1403,16 +1405,16 @@ build_detail_overlay <- function() {
 build_map_loading_overlay <- function() {
   htmltools::tags$div(
     id = "map-loading-overlay",
-    style = "display: none; position: fixed; top: var(--bslib-navbar-height, 58px); left: 0; 
-             width: 100vw; height: calc(100vh - var(--bslib-navbar-height, 58px));
+    style = "display: none; position: fixed; top: var(--bslib-navbar-height, 57px); left: 0; 
+             width: 100vw; height: calc(100vh - var(--bslib-navbar-height, 57px));
              background: rgba(255, 255, 255, 0.98); z-index: 1200;
              justify-content: center; align-items: center; flex-direction: column;",
     htmltools::tags$div(
       class = "map-loading-content",
       style = "text-align: center; margin-top: -5rem;",
       htmltools::tags$h2(
-        "Loading the Map for the first time can take a few seconds. It's busy:",
-        style = "font-size: 1rem; color: var(--no-status-text); font-weight: 500; margin-bottom: 1.5rem;"
+        "Loading the map for the first time can take a few seconds. It's busy:",
+        style = "font-size: 0.875rem; color: var(--no-status-text); margin-bottom: 1.5rem;"
       ),
       htmltools::tags$div(
         class = "map-loading-ellipses",
@@ -1423,7 +1425,7 @@ build_map_loading_overlay <- function() {
       ),
       htmltools::tags$div(
         id = "map-loading-pun",
-        style = "font-size: 1rem; color: var(--vb-green); font-weight: 500;"
+        style = "font-size: 1rem; color: var(--vb-green); font-weight: 500;",
       )
     )
   )

--- a/R/ui.R
+++ b/R/ui.R
@@ -1114,6 +1114,19 @@ custom_theme <- bslib::bs_add_rules(
       background-color: rgba(114, 185, 162, 0.25) !important;
   }
   
+  /* DataTables loading indicator customization */
+  .dataTables_processing {
+      z-index: 1000 !important;
+      position: absolute !important;
+      top: 50% !important;
+      left: 50% !important;
+  }
+  
+  /* Target the nested divs that create the loading animation */
+  .dataTables_processing > div > div {
+      background-color: #72B9A2 !important;
+  }
+  
   /* Map loading overlay animations */
   @keyframes spin {
     0% { transform: rotate(0deg); }

--- a/R/ui.R
+++ b/R/ui.R
@@ -1127,10 +1127,57 @@ custom_theme <- bslib::bs_add_rules(
       background-color: #72B9A2 !important;
   }
   
-  /* Map loading overlay animations */
-  @keyframes spin {
-    0% { transform: rotate(0deg); }
-    100% { transform: rotate(360deg); }
+  /* Map loading ellipses animation */
+  .map-loading-ellipses {
+      display: inline-block;
+      position: relative;
+      margin-bottom: 1rem;
+      width: 9.375rem;
+      height: 1.5rem;
+  }
+  
+  .map-loading-ellipses > div {
+      position: absolute;
+      width: 1.5rem;
+      height: 1.5rem;
+      border-radius: 50%;
+      background: #72B9A2;
+      animation-timing-function: cubic-bezier(0, 1, 1, 0);
+  }
+  
+  .map-loading-ellipses > div:nth-child(1) {
+      left: 0.75rem;
+      animation: mapEllipses1 0.6s infinite;
+  }
+  
+  .map-loading-ellipses > div:nth-child(2) {
+      left: 0.75rem;
+      animation: mapEllipses2 0.6s infinite;
+  }
+  
+  .map-loading-ellipses > div:nth-child(3) {
+      left: 3.75rem;
+      animation: mapEllipses2 0.6s infinite;
+  }
+  
+  .map-loading-ellipses > div:nth-child(4) {
+      left: 6.75rem;
+      animation: mapEllipses3 0.6s infinite;
+  }
+  
+  @keyframes mapEllipses1 {
+    0% { transform: scale(0); }
+    100% { transform: scale(1); }
+  }
+  
+  @keyframes mapEllipses2 {
+    0% { transform: translate(0, 0); }
+    100% { transform: translate(3rem, 0); }
+  }
+  
+  @keyframes mapEllipses3 {
+    0% { transform: scale(1); }
+    100% { transform: scale(0); }
   }
   
   @keyframes fadeOut {
@@ -1362,22 +1409,21 @@ build_map_loading_overlay <- function() {
              justify-content: center; align-items: center; flex-direction: column;",
     htmltools::tags$div(
       class = "map-loading-content",
-      style = "text-align: center;",
+      style = "text-align: center; margin-top: -5rem;",
       htmltools::tags$h2(
         "Loading the Map for the first time can take a few seconds. It's busy:",
         style = "font-size: 1rem; color: var(--no-status-text); font-weight: 500; margin-bottom: 1.5rem;"
       ),
       htmltools::tags$div(
-        class = "map-loading-spinner",
-        style = "width: 80px; height: 80px; margin: 0 auto 2rem auto;
-                 border: 8px solid rgba(114, 185, 162, 0.2);
-                 border-top-color: #72B9A2;
-                 border-radius: 50%;
-                 animation: spin 1s linear infinite;"
+        class = "map-loading-ellipses",
+        htmltools::tags$div(htmltools::tags$div()),
+        htmltools::tags$div(htmltools::tags$div()),
+        htmltools::tags$div(htmltools::tags$div()),
+        htmltools::tags$div(htmltools::tags$div())
       ),
       htmltools::tags$div(
         id = "map-loading-pun",
-        style = "font-size: 1rem; color: var(--vb-green); font-weight: 500; min-height: 2rem;"
+        style = "font-size: 1rem; color: var(--vb-green); font-weight: 500;"
       )
     )
   )

--- a/R/ui.R
+++ b/R/ui.R
@@ -21,6 +21,7 @@ ui <- function(req) {
 
   navbar_with_search <- build_navbar()
   overlay <- build_detail_overlay()
+  map_loading_overlay <- build_map_loading_overlay()
 
   script <- htmltools::tags$script(htmltools::HTML(
     "Shiny.addCustomMessageHandler('openOverlay', function(message) {
@@ -541,6 +542,64 @@ ui <- function(req) {
       setNavbarDisabled(disabled);
     });
 
+    // Map loading overlay management
+    var mapLoadingPuns = [
+      'Planting seeds...',
+      'Branching out...',
+      'Rooting through the database...',
+      'Monitoring mycelial networks...',
+      'Disturbing the substrate...',
+      'Planning successful succession...',
+      'Last bud not leaf...'
+    ];
+    var mapLoadingPunIndex = 0;
+    var mapLoadingPunInterval = null;
+
+    function rotatePlantPun() {
+      var punElement = document.getElementById('map-loading-pun');
+      if (punElement) {
+        punElement.textContent = mapLoadingPuns[mapLoadingPunIndex];
+        mapLoadingPunIndex = (mapLoadingPunIndex + 1) % mapLoadingPuns.length;
+      }
+    }
+
+    Shiny.addCustomMessageHandler('showMapLoading', function(message) {
+      var overlay = document.getElementById('map-loading-overlay');
+      if (overlay) {
+        overlay.style.display = 'flex';
+        overlay.classList.remove('fade-out');
+        mapLoadingPunIndex = 0;
+        rotatePlantPun();
+        if (mapLoadingPunInterval) {
+          clearInterval(mapLoadingPunInterval);
+        }
+        mapLoadingPunInterval = setInterval(rotatePlantPun, 2500);
+      }
+    });
+
+    Shiny.addCustomMessageHandler('hideMapLoading', function(message) {
+      var overlay = document.getElementById('map-loading-overlay');
+      var punElement = document.getElementById('map-loading-pun');
+      
+      if (mapLoadingPunInterval) {
+        clearInterval(mapLoadingPunInterval);
+        mapLoadingPunInterval = null;
+      }
+      
+      if (overlay && punElement) {
+        punElement.textContent = 'Go fir launch!';
+        
+        setTimeout(function() {
+          // Allow interaction immediately by removing pointer events
+          overlay.style.pointerEvents = 'none';
+          overlay.classList.add('fade-out');
+          setTimeout(function() {
+            overlay.style.display = 'none';
+          }, 500);
+        }, 500);
+      }
+    });
+
     function getDataTableApi(tableId, settings) {
       if (settings && $.fn && $.fn.dataTable) {
         try {
@@ -923,7 +982,7 @@ ui <- function(req) {
   "
   ))
 
-  htmltools::tagList(font_head, navbar_with_search, overlay, script)
+  htmltools::tagList(font_head, navbar_with_search, overlay, map_loading_overlay, script)
 }
 
 #' Custom Bootstrap Theme for Vegbank Web Application
@@ -1053,6 +1112,21 @@ custom_theme <- bslib::bs_add_rules(
   table.dataTable tbody tr.selected-entity:hover,
   .table tbody tr.selected-entity:hover {
       background-color: rgba(114, 185, 162, 0.25) !important;
+  }
+  
+  /* Map loading overlay animations */
+  @keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+  }
+  
+  @keyframes fadeOut {
+    from { opacity: 1; }
+    to { opacity: 0; }
+  }
+  
+  #map-loading-overlay.fade-out {
+    animation: fadeOut 0.5s ease-out forwards;
   }
 "
 )
@@ -1252,6 +1326,39 @@ build_detail_overlay <- function() {
           bslib::card(bslib::card_header("Details"), shiny::uiOutput("stratum_method_details")),
           bslib::card(bslib::card_header("Stratum Types"), shiny::uiOutput("stratum_types"))
         )
+      )
+    )
+  )
+}
+
+#' Build Map Loading Overlay for Vegbank UI
+#'
+#' Constructs a full-screen loading overlay for initial map loading with animated
+#' spinner and rotating plant puns.
+#'
+#' @return A Shiny tag representing the map loading overlay.
+#'
+#' @noRd
+build_map_loading_overlay <- function() {
+  htmltools::tags$div(
+    id = "map-loading-overlay",
+    style = "display: none; position: fixed; top: 0; left: 0; width: 100vw; height: 100vh;
+             background: rgba(255, 255, 255, 0.98); z-index: 9999;
+             justify-content: center; align-items: center; flex-direction: column;",
+    htmltools::tags$div(
+      class = "map-loading-content",
+      style = "text-align: center;",
+      htmltools::tags$div(
+        class = "map-loading-spinner",
+        style = "width: 80px; height: 80px; margin: 0 auto 2rem auto;
+                 border: 8px solid rgba(114, 185, 162, 0.2);
+                 border-top-color: #72B9A2;
+                 border-radius: 50%;
+                 animation: spin 1s linear infinite;"
+      ),
+      htmltools::tags$div(
+        id = "map-loading-pun",
+        style = "font-size: 1rem; color: var(--vb-green); font-weight: 500; min-height: 2rem;"
       )
     )
   )

--- a/tests/testthat/test_project_table.R
+++ b/tests/testthat/test_project_table.R
@@ -33,7 +33,7 @@ test_that("project table spec wires AJAX data source", {
   expect_true(is.function(spec$normalize_fn))
   expect_true(is.function(spec$display_fn))
   expect_equal(colnames(spec$empty_factory()), PROJECT_TABLE_FIELDS)
-  expect_match(config$options$language$processing, "project records", ignore.case = TRUE)
+  expect_match(config$options$language$processing, "projects", ignore.case = TRUE)
 })
 
 test_that("process_project_data formats normalized data", {


### PR DESCRIPTION
## What
This PR implements a few bugfixes and usability updates. It first fixes #134 by locking the navbar and displaying a loading screen modeled that rotates through punny loading messages until the map is ready for interaction. It also moves the detail drawer below the nav bar so that it is also obscured by the loading screen and the nav bar can be extended with a login button in or search bar the upper right in future if needed. It also customized the DT loading ellipses animation to match the green app theme color, implements a similar but bigger ellipses animation on the map loading screen, and updates the table loading messages for better consistency. Finally, I (hopefully) solved #28 by invalidating map size whenever the app loads the map page (not just when the show_on_map) button is clicked.

## Why
Because clicking the nav bar while the map loaded caused it to never initialize, navigating away from the map opening the detail drawer and returning to the map made it glitch until you resized the window, and the table loading animations were inconsisstent.

## How

- Created new loader overlay in ui.R for map
- Added map_initialized state to server.R to track if map has been loaded and observed leaflet events to dismiss loading screen
- Styled that overlay and the detail drawer to fit under the nav bar
- Overrode the DT styles to make the tables' ellipses animation green 
- Made an ellipses animation like it but bigger for the map page using css animations in ui.R
- Renamed remote_label to loading_label for more descriptive naming in tables
- Removed "records" from parties and projects loading messages so they now match the other tables
- Added an event listener to server.R that invalidates the map size (like the show_on_map button does) anytime the map page is loaded

## Testing and Documentation
All 730 tests still pass and check() throws the same 3 Notes.