### PR TITLE
Replace author_obs_codes in map links with ob_codes 

### DIFF
--- a/R/map.R
+++ b/R/map.R
@@ -126,7 +126,7 @@ show_map_validation_error <- function(reason) {
 #' on validation failure and returns an empty map as fallback.
 #'
 #' @param map_data Data frame with map points. Must contain latitude, longitude,
-#'                author_obs_code and ob_code columns.
+#'                 and ob_code columns.
 #' @param center_lng Longitude for map center (numeric)
 #' @param center_lat Latitude for map center (numeric)
 #' @param zoom Initial zoom level (integer)

--- a/R/map.R
+++ b/R/map.R
@@ -88,7 +88,7 @@ validate_map_data <- function(map_data) {
 is_invalid_map_data <- function(map_data) {
   is.null(map_data) ||
     nrow(map_data) == 0 ||
-    !all(c("latitude", "longitude", "author_obs_code", "ob_code") %in% colnames(map_data))
+    !all(c("latitude", "longitude", "ob_code") %in% colnames(map_data))
 }
 
 #' Filter map data to only include points with valid coordinates
@@ -198,12 +198,11 @@ update_map_view <- function(map_proxy, lng, lat, label, zoom = NULL) {
 #' @noRd
 group_map_points <- function(valid_points) {
   valid_points |>
-    dplyr::arrange(.data$author_obs_code) |>
+    dplyr::arrange(.data$ob_code) |>
     dplyr::group_by(.data$latitude, .data$longitude) |>
     dplyr::summarize(
       obs_count = dplyr::n(),
-      author_obs_code_label = create_marker_popup(
-        .data$author_obs_code,
+      obs_code_label = create_marker_popup(
         .data$ob_code,
         dplyr::n()
       ),
@@ -241,7 +240,7 @@ build_leaflet_map <- function(data_grouped, map_defaults, center_lng, center_lat
       lng = ~longitude,
       lat = ~latitude,
       layerId = ~ paste(latitude, longitude, sep = ", "),
-      label = ~ author_obs_code_label |> lapply(htmltools::HTML),
+      label = ~ obs_code_label |> lapply(htmltools::HTML),
       labelOptions = create_marker_label_options(),
       clusterOptions = leaflet::markerClusterOptions(disableClusteringAtZoom = 17)
     ) |>
@@ -305,30 +304,28 @@ create_empty_map <- function(map_defaults = NULL, center_lng = NULL, center_lat 
 
 #' Create a marker popup HTML for a group of observations
 #'
-#' @param author_obs_codes Character vector of author observation codes
 #' @param ob_codes Character vector of plot observation VegBank codes
 #' @param count Integer, number of observations for that plot
 #' @return A string containing HTML for the popup label
 #' @noRd
-create_marker_popup <- function(author_obs_codes, ob_codes, count) {
+create_marker_popup <- function(ob_codes, count) {
   header <- ifelse(count == 1, "1 Observation", paste(count, "Observations"))
 
   links <- mapply(
-    function(author_obs_code, ob_code) {
+    function(ob_code) {
       # Not using create_detail_link here bc direct string manipulation is slightly faster
       safe_ob <- htmltools::htmlEscape(ob_code, attribute = TRUE)
-      safe_author <- htmltools::htmlEscape(author_obs_code)
       sprintf(
         "<a href=\"#\" onclick=\"Shiny.setInputValue('plot_link_click', '%s', {priority: 'event'}); return false;\">%s</a>",
-        safe_ob, safe_author
+        safe_ob, safe_ob
       )
     },
-    author_obs_codes, ob_codes
+    ob_codes
   )
 
   paste0(
     "<strong>", header, "</strong>",
-    "<div style='max-height: 15.5rem; overflow-y: auto;' onwheel='event.stopPropagation()'",
+    "<div style='max-height: 8rem; overflow-y: auto;' onwheel='event.stopPropagation()'",
     " onmousewheel='event.stopPropagation()' onDOMMouseScroll='event.stopPropagation()'>",
     paste(links, collapse = "<br>"),
     "</div>"

--- a/R/server.R
+++ b/R/server.R
@@ -1093,7 +1093,7 @@ server <- function(input, output, session) {
             session,
             map_req$lat,
             map_req$lng,
-            paste("Plot", map_req$code, "is here!")
+            paste(map_req$code, "is here!")
           )
           state$map_request(NULL)
 

--- a/R/table_plot.R
+++ b/R/table_plot.R
@@ -114,7 +114,7 @@ process_plot_data <- function(plot_data) {
   elevations <- suppressWarnings(as.numeric(plot_data$elevation))
 
   locations <- format_location_column(plot_data, latitudes, longitudes, elevations)
-  actions_html <- format_plot_action_buttons(ob_codes, author_codes, latitudes, longitudes)
+  actions_html <- format_plot_action_buttons(ob_codes, latitudes, longitudes)
   top_taxa_html <- format_plot_taxa_list(plot_data$top_taxon_observations, plot_data$taxon_count)
   communities_html <- format_plot_community_list(plot_data$top_classifications)
 
@@ -133,30 +133,28 @@ process_plot_data <- function(plot_data) {
 #' Format HTML for plot table action buttons (Details + Map)
 #'
 #' @param ob_codes Character vector of plot observation codes
-#' @param author_codes Character vector of author observation codes
 #' @param latitudes Numeric vector of latitudes
 #' @param longitudes Numeric vector of longitudes
 #' @return Character vector of HTML for action buttons
 #' @noRd
-format_plot_action_buttons <- function(ob_codes, author_codes, latitudes, longitudes) {
+format_plot_action_buttons <- function(ob_codes, latitudes, longitudes) {
   row_count <- length(ob_codes)
   vapply(seq_len(row_count), function(idx) {
-    detail_code <- ob_codes[[idx]]
+    ob_code <- ob_codes[[idx]]
     lat <- latitudes[[idx]]
     lng <- longitudes[[idx]]
-    code <- author_codes[[idx]]
     has_coords <- !is.na(lat) && !is.na(lng)
     # Details button
-    detail_btn <- if (!is.null(detail_code) && nzchar(detail_code)) {
+    detail_btn <- if (!is.null(ob_code) && nzchar(ob_code)) {
       sprintf(
         '<button type="button" class="btn btn-sm btn-outline-primary dt-shiny-action" data-input-id="plot_link_click" data-value="%s">Details</button>',
-        htmltools::htmlEscape(detail_code, attribute = TRUE))
+        htmltools::htmlEscape(ob_code, attribute = TRUE))
     } else {
       '<button type="button" class="btn btn-sm btn-outline-primary" disabled>Details</button>'
     }
     # Map button
     map_btn <- if (has_coords) {
-      code_attr <- if (!is.null(code) && nzchar(code)) sprintf(' data-code="%s"', htmltools::htmlEscape(code, attribute = TRUE)) else ''
+      code_attr <- if (!is.null(ob_code) && nzchar(ob_code)) sprintf(' data-code="%s"', htmltools::htmlEscape(ob_code, attribute = TRUE)) else ''
       sprintf(
         '<button type="button" class="btn btn-sm btn-outline-primary dt-map-action" data-lat="%s" data-lng="%s"%s>Map</button>',
         htmltools::htmlEscape(lat, attribute = TRUE),

--- a/tests/testthat/test_plot_map.R
+++ b/tests/testthat/test_plot_map.R
@@ -14,41 +14,29 @@ test_that("get_map_defaults returns expected structure", {
 
 test_that("create_marker_popup creates correct HTML", {
   # Single observation
-  single_popup <- create_marker_popup("Plot1", "ACC1", 1)
+  single_popup <- create_marker_popup("ob.13455", 1)
   expect_true(grepl("<strong>1 Observation</strong>", single_popup))
   # Single quotes are safe within double-quoted attributes
-  expect_true(grepl("onclick=\"Shiny.setInputValue\\('plot_link_click',\\s*'ACC1'", single_popup))
-  expect_true(grepl(">Plot1</a>", single_popup))
+  expect_true(grepl("onclick=\"Shiny.setInputValue\\('plot_link_click',\\s*'ob.13455'", single_popup))
+  expect_true(grepl(">ob.13455</a>", single_popup))
 
   # Multiple observations
   multi_popup <- create_marker_popup(
-    c("Plot1", "Plot2"),
-    c("ACC1", "ACC2"),
+    c("ob.13455", "ob.45436"),
     2
   )
   expect_true(grepl("<strong>2 Observations</strong>", multi_popup))
-  expect_true(grepl(">Plot1</a>", multi_popup))
-  expect_true(grepl(">Plot2</a>", multi_popup))
+  expect_true(grepl(">ob.13455</a>", multi_popup))
+  expect_true(grepl(">ob.45436</a>", multi_popup))
   expect_true(grepl("<br>", multi_popup))
 })
 
 # ---- XSS Prevention tests ----
 
-test_that("create_marker_popup prevents XSS in author_obs_code", {
-  # Test HTML injection in display text
-  xss_obs <- "<script>alert('xss')</script>"
-  popup <- create_marker_popup(xss_obs, "ACC1", 1)
-
-  # Should NOT contain raw script tag
-  expect_false(grepl("<script>", popup, fixed = TRUE))
-  # Should contain escaped version
-  expect_true(grepl("&lt;script&gt;", popup, fixed = TRUE))
-})
-
 test_that("create_marker_popup prevents XSS in ob_code", {
   # Test JS injection in onclick handler
-  xss_acc <- "'); alert('xss'); //"
-  popup <- create_marker_popup("Plot1", xss_acc, 1)
+  xss_code <- "'); alert('xss'); //"
+  popup <- create_marker_popup(xss_code, 1)
 
   # Should NOT contain unescaped single quote followed by closing paren
   # that could break out of the JS string (the raw pattern "');")
@@ -59,16 +47,12 @@ test_that("create_marker_popup prevents XSS in ob_code", {
 
 test_that("create_marker_popup handles special characters safely", {
   # Test various edge cases
-  special_obs <- "Plot's \"Name\" <test> & more"
-  special_acc <- "ob.123/456"
+  special_code <- "ob.123/456"
 
-  popup <- create_marker_popup(special_obs, special_acc, 1)
+  popup <- create_marker_popup(special_code, 1)
 
   # Display text should be HTML escaped for text content
   # Note: htmlEscape() without attribute=TRUE doesn't escape quotes/apostrophes in text nodes (they're safe there)
-  expect_true(grepl("&lt;test&gt;", popup)) # escaped angle brackets
-  expect_true(grepl("&amp;", popup)) # escaped ampersand
-
   # JS string value is HTML escaped - forward slashes are safe and not escaped
   expect_true(grepl("ob.123/456", popup, fixed = TRUE))
 })
@@ -98,7 +82,6 @@ test_that("validate_map_data returns invalid when all coordinates are NA", {
   bad_coords <- data.frame(
     latitude = NA,
     longitude = NA,
-    author_obs_code = "CODE",
     ob_code = "ob.1"
   )
   result <- validate_map_data(bad_coords)
@@ -110,7 +93,6 @@ test_that("validate_map_data returns valid with good data", {
   good_data <- data.frame(
     latitude = 40.7128,
     longitude = -74.0060,
-    author_obs_code = "NYC",
     ob_code = "ob.2948"
   )
   result <- validate_map_data(good_data)
@@ -122,13 +104,12 @@ test_that("validate_map_data filters out NA coordinates", {
   mixed_data <- data.frame(
     latitude = c(40.7128, NA, 34.0522),
     longitude = c(-74.0060, -100, NA),
-    author_obs_code = c("NYC", "BAD1", "BAD2"),
     ob_code = c("ob.1", "ob.2", "ob.3")
   )
   result <- validate_map_data(mixed_data)
   expect_true(result$valid)
   expect_equal(nrow(result$data), 1)
-  expect_equal(result$data$author_obs_code, "NYC")
+  expect_equal(result$data$ob_code, "ob.1")
 })
 
 # ---- process_map_data tests ----
@@ -154,7 +135,6 @@ test_that("process_map_data creates a map with markers", {
   test_data <- data.frame(
     latitude = c(40.7128, 34.0522),
     longitude = c(-74.0060, -118.2437),
-    author_obs_code = c("NYC", "LA"),
     ob_code = c("ob.2948", "ob.2949"),
     stringsAsFactors = FALSE
   )
@@ -172,7 +152,6 @@ test_that("process_map_data handles custom center and zoom", {
   test_data <- data.frame(
     latitude = c(40.7128),
     longitude = c(-74.0060),
-    author_obs_code = c("NYC"),
     ob_code = c("ob.2948"),
     stringsAsFactors = FALSE
   )
@@ -188,7 +167,6 @@ test_that("fetch_plot_map_data returns data when API succeeds", {
   fake_data <- data.frame(
     latitude = 10,
     longitude = 20,
-    author_obs_code = "CODE",
     ob_code = "ob.1"
   )
 


### PR DESCRIPTION
## What
Closes #89 by replacing author_obs_codes in map links with ob_codes and shrinks label height to 8 rem.

## Why
To be more consistent with how we identify plot observations in the plot table and throughout vegbank. Vb codes are the more standardized identifier, though they do offer less implicit information about which project an observation may be from. And a shorter label height because someone commented on "tables" appearing and this should hopefully make it feel less cluttered.

## How

- Removed all mentions of author_obs_code from map and map tests
- Replaced map label links with ob.codes
- Replaced "Plot author_obs_code is here!" message with "ob.code is here!"

## Testing and Documentation
All 726 tests pass, check() runs with only normal 3 notes