### PR TITLE
Features 141, 142, 144 newer ob version notification, wider detail panel, soil & disturbance details

### DIFF
--- a/R/detail_helpers.R
+++ b/R/detail_helpers.R
@@ -146,7 +146,7 @@ append_units <- function(field_name, value) {
     clay = " %",
     coarse = " %",
     organic = " %",
-    base_saturation = " %",
+    base_saturation = " %"
   )
 
   if (field_name %in% names(unit_map)) {

--- a/R/detail_helpers.R
+++ b/R/detail_helpers.R
@@ -140,7 +140,13 @@ append_units <- function(field_name, value) {
     growthform_2_cover = " %",
     growthform_3_cover = " %",
     growthform_4_cover = " %",
-    total_cover = " %"
+    total_cover = " %",
+    sand = " %",
+    silt = " %",
+    clay = " %",
+    coarse = " %",
+    organic = " %",
+    base_saturation = " %",
   )
 
   if (field_name %in% names(unit_map)) {

--- a/R/detail_plot.R
+++ b/R/detail_plot.R
@@ -162,7 +162,7 @@ build_plot_obs_details_view <- function(result) {
   # Cover method display (link or fallback) for methods_details card
   # Must use list() to wrap HTML tag objects for tibble compatibility
   if (has_valid_field_value(plot_observation, "cm_code") &&
-    has_valid_field_value(plot_observation, "cover_method_name")) {
+        has_valid_field_value(plot_observation, "cover_method_name")) {
     plot_observation$cover_method_display <- list(create_detail_link(
       "cover_method_link_click",
       plot_observation$cm_code,
@@ -175,7 +175,7 @@ build_plot_obs_details_view <- function(result) {
   # Stratum method display (link or fallback) for methods_details card
   # Must use list() to wrap HTML tag objects for tibble compatibility
   if (has_valid_field_value(plot_observation, "sm_code") &&
-    has_valid_field_value(plot_observation, "stratum_method_name")) {
+        has_valid_field_value(plot_observation, "stratum_method_name")) {
     plot_observation$stratum_method_display <- list(create_detail_link(
       "stratum_method_link_click",
       plot_observation$sm_code,
@@ -250,6 +250,83 @@ build_plot_obs_details_view <- function(result) {
     )
   })
 
+  disturbances_details_ui <- shiny::renderUI({
+    tryCatch(
+      {
+        disturbances <- normalized$disturbances
+
+        if (is.null(disturbances) || nrow(disturbances) == 0) {
+          return(htmltools::tags$p("No disturbances recorded"))
+        }
+
+        rows <- lapply(seq_len(nrow(disturbances)), function(i) {
+          row <- disturbances[i, , drop = FALSE]
+
+          type_val <- row$type %|||% "Not recorded"
+          intensity_val <- row$intensity %|||% "Not recorded"
+          comment_val <- row$comment %|||% "Not recorded"
+
+          htmltools::tags$tr(
+            htmltools::tags$td(type_val),
+            htmltools::tags$td(intensity_val),
+            htmltools::tags$td(comment_val)
+          )
+        })
+
+        create_detail_table_with_headers(
+          c("Type", "Intensity", "Comment"),
+          rows,
+          table_style = "width: 100%; table-layout: fixed; word-break: break-word;"
+        )
+      },
+      error = function(e) {
+        message("Error in disturbances_details: ", e$message)
+        htmltools::tags$p(paste("Error processing disturbances:", e$message))
+      }
+    )
+  })
+
+  soils_details_ui <- shiny::renderUI({
+    tryCatch(
+      {
+        soils <- normalized$soils
+
+        if (is.null(soils) || nrow(soils) == 0) {
+          return(htmltools::tags$p("No soil data recorded"))
+        }
+
+        soil_sections <- lapply(seq_len(nrow(soils)), function(i) {
+          soil <- soils[i, , drop = FALSE]
+          horizon_label <- soil$horizon %|||% "Unknown"
+
+          # Get all non-null fields for this soil
+          fields_to_show <- c(
+            "description", "depth_top", "depth_bottom", "texture", "color",
+            "ph", "organic", "sand", "silt", "clay", "coarse",
+            "exchange_capacity", "base_saturation"
+          )
+
+          htmltools::div(
+            style = "margin-bottom: 1rem;",
+            create_section_header(paste("Horizon:", horizon_label)),
+            format_fields_for_detail_table(
+              fields_to_show,
+              soil,
+              skip_empty = TRUE,
+              apply_units = TRUE
+            )
+          )
+        })
+
+        htmltools::div(soil_sections)
+      },
+      error = function(e) {
+        message("Error in soils_details: ", e$message)
+        htmltools::tags$p(paste("Error processing soils:", e$message))
+      }
+    )
+  })
+
   list(
     plot_notification = shiny::renderUI({
       # Show notification if observation has been replaced
@@ -284,7 +361,7 @@ build_plot_obs_details_view <- function(result) {
           htmltools::tags$p(format_date_range(plot_observation$obs_start_date, plot_observation$obs_end_date))
         },
         if (has_valid_field_value(plot_observation, "rf_code") &&
-          has_valid_field_value(plot_observation, "rf_label")) {
+              has_valid_field_value(plot_observation, "rf_label")) {
           htmltools::tags$p(
             htmltools::tags$span("Reference: "),
             create_detail_link("ref_link_click", plot_observation$rf_code, plot_observation$rf_label)
@@ -341,81 +418,6 @@ build_plot_obs_details_view <- function(result) {
       skip_empty = TRUE,
       apply_units = TRUE
     ),
-    disturbances_details = shiny::renderUI({
-      tryCatch(
-        {
-          disturbances <- normalized$disturbances
-
-          if (is.null(disturbances) || nrow(disturbances) == 0) {
-            return(htmltools::tags$p("No disturbances recorded"))
-          }
-
-          rows <- lapply(seq_len(nrow(disturbances)), function(i) {
-            row <- disturbances[i, , drop = FALSE]
-
-            type_val <- row$type %|||% "Not recorded"
-            intensity_val <- row$intensity %|||% "Not recorded"
-            comment_val <- row$comment %|||% "Not recorded"
-
-            htmltools::tags$tr(
-              htmltools::tags$td(type_val),
-              htmltools::tags$td(intensity_val),
-              htmltools::tags$td(comment_val)
-            )
-          })
-
-          create_detail_table_with_headers(
-            c("Type", "Intensity", "Comment"),
-            rows,
-            table_style = "width: 100%; table-layout: fixed; word-break: break-word;"
-          )
-        },
-        error = function(e) {
-          message("Error in disturbances_details: ", e$message)
-          htmltools::tags$p(paste("Error processing disturbances:", e$message))
-        }
-      )
-    }),
-    soils_details = shiny::renderUI({
-      tryCatch(
-        {
-          soils <- normalized$soils
-
-          if (is.null(soils) || nrow(soils) == 0) {
-            return(htmltools::tags$p("No soil data recorded"))
-          }
-
-          soil_sections <- lapply(seq_len(nrow(soils)), function(i) {
-            soil <- soils[i, , drop = FALSE]
-            horizon_label <- soil$horizon %|||% "Unknown"
-
-            # Get all non-null fields for this soil
-            fields_to_show <- c(
-              "description", "depth_top", "depth_bottom", "texture", "color",
-              "ph", "organic", "sand", "silt", "clay", "coarse",
-              "exchange_capacity", "base_saturation"
-            )
-
-            htmltools::div(
-              style = "margin-bottom: 1rem;",
-              create_section_header(paste("Horizon:", horizon_label)),
-              format_fields_for_detail_table(
-                fields_to_show,
-                soil,
-                skip_empty = TRUE,
-                apply_units = TRUE
-              )
-            )
-          })
-
-          htmltools::div(soil_sections)
-        },
-        error = function(e) {
-          message("Error in soils_details: ", e$message)
-          htmltools::tags$p(paste("Error processing soils:", e$message))
-        }
-      )
-    }),
     methods_details = render_detail_table(
       c(
         "method_narrative", "placement_method", "cover_method_display", "cover_dispersion",
@@ -446,12 +448,14 @@ build_plot_obs_details_view <- function(result) {
       skip_empty = TRUE,
       apply_units = TRUE
     ),
+    communities_details = communities_details_ui,
+    taxa_details = taxa_details_ui,
+    disturbances_details = disturbances_details_ui,
+    soils_details = soils_details_ui,
     plot_misc_details = render_detail_table(
       c("original_data", "parent_pl_code", "pl_revisions", "pl_notes_public", "pl_notes_mgt"),
       plot_observation,
       skip_empty = TRUE
-    ),
-    taxa_details = taxa_details_ui,
-    communities_details = communities_details_ui
+    )
   )
 }

--- a/R/detail_plot.R
+++ b/R/detail_plot.R
@@ -216,7 +216,9 @@ build_plot_obs_details_view <- function(result) {
             c("Name", "Stratum", "Cover"),
             rows,
             table_style = "width: 100%; table-layout: fixed; word-break: break-word;",
-            header_styles = c("text-align: left;", "text-align: left;", "text-align: right;")
+            header_styles = c("width: 40%; text-align: left;",
+                              "width: 35%; text-align: left;",
+                              "width: 25%; text-align: right;")
           )
         )
       },
@@ -276,7 +278,8 @@ build_plot_obs_details_view <- function(result) {
         create_detail_table_with_headers(
           c("Type", "Intensity", "Comment"),
           rows,
-          table_style = "width: 100%; table-layout: fixed; word-break: break-word;"
+          table_style = "width: 100%; table-layout: fixed; word-break: break-word;",
+          header_styles = c("width: 30%;", "width: 30%;", "width: 40%;")
         )
       },
       error = function(e) {

--- a/R/detail_plot.R
+++ b/R/detail_plot.R
@@ -1,9 +1,9 @@
 #' @noRd
 plot_detail_output_names <- c(
-  "plot_header",
+  "plot_notification", "plot_header",
   "author_code_details", "date_details", "location_details", "layout_details",
   "environmental_details", "methods_details", "plot_quality_details", "plot_vegetation_details",
-  "plot_misc_details", "taxa_details", "communities_details"
+  "communities_details", "taxa_details", "disturbances_details", "soils_details", "plot_misc_details"
 )
 
 #' Normalize Plot Observation Result Payload
@@ -41,8 +41,13 @@ normalize_plot_obs_result <- function(result) {
   plot_observation <- result[1, , drop = FALSE]
   taxa <- extract_nested_table(plot_observation, "top_taxon_observations")
   communities <- extract_nested_table(plot_observation, "top_classifications")
+  disturbances <- extract_nested_table(plot_observation, "disturbances")
+  soils <- extract_nested_table(plot_observation, "soils")
 
-  nested_cols <- intersect(c("top_taxon_observations", "top_classifications"), names(plot_observation))
+  nested_cols <- intersect(
+    c("top_taxon_observations", "top_classifications", "disturbances", "soils"), names(plot_observation)
+  )
+
   if (length(nested_cols) > 0) {
     plot_observation[nested_cols] <- NULL
   }
@@ -51,6 +56,8 @@ normalize_plot_obs_result <- function(result) {
     plot_observation = plot_observation,
     top_taxon_observations = taxa,
     communities = communities,
+    disturbances = disturbances,
+    soils = soils,
     has_data = TRUE
   )
 }
@@ -155,7 +162,7 @@ build_plot_obs_details_view <- function(result) {
   # Cover method display (link or fallback) for methods_details card
   # Must use list() to wrap HTML tag objects for tibble compatibility
   if (has_valid_field_value(plot_observation, "cm_code") &&
-        has_valid_field_value(plot_observation, "cover_method_name")) {
+    has_valid_field_value(plot_observation, "cover_method_name")) {
     plot_observation$cover_method_display <- list(create_detail_link(
       "cover_method_link_click",
       plot_observation$cm_code,
@@ -168,7 +175,7 @@ build_plot_obs_details_view <- function(result) {
   # Stratum method display (link or fallback) for methods_details card
   # Must use list() to wrap HTML tag objects for tibble compatibility
   if (has_valid_field_value(plot_observation, "sm_code") &&
-        has_valid_field_value(plot_observation, "stratum_method_name")) {
+    has_valid_field_value(plot_observation, "stratum_method_name")) {
     plot_observation$stratum_method_display <- list(create_detail_link(
       "stratum_method_link_click",
       plot_observation$sm_code,
@@ -244,6 +251,24 @@ build_plot_obs_details_view <- function(result) {
   })
 
   list(
+    plot_notification = shiny::renderUI({
+      # Show notification if observation has been replaced
+      if (isTRUE(plot_observation$has_observation_synonym) &&
+            has_valid_field_value(plot_observation, "replaced_by_ob_code")) {
+        return(htmltools::tags$div(
+          class = "alert alert-warning",
+          style = "padding: 0.5rem; margin-bottom: 0.75rem; font-size: 0.875rem;",
+          htmltools::tags$b("This observation has been updated."),
+          htmltools::tags$br(),
+          create_detail_link(
+            "plot_link_click",
+            plot_observation$replaced_by_ob_code,
+            "View the newer version."
+          )
+        ))
+      }
+      return(NULL)
+    }),
     plot_header = shiny::renderUI({
       htmltools::div(
         htmltools::tags$h5(plot_observation$author_obs_code, style = "font-weight: 600; margin-bottom: 0px;"),
@@ -259,7 +284,7 @@ build_plot_obs_details_view <- function(result) {
           htmltools::tags$p(format_date_range(plot_observation$obs_start_date, plot_observation$obs_end_date))
         },
         if (has_valid_field_value(plot_observation, "rf_code") &&
-              has_valid_field_value(plot_observation, "rf_label")) {
+          has_valid_field_value(plot_observation, "rf_label")) {
           htmltools::tags$p(
             htmltools::tags$span("Reference: "),
             create_detail_link("ref_link_click", plot_observation$rf_code, plot_observation$rf_label)
@@ -316,6 +341,81 @@ build_plot_obs_details_view <- function(result) {
       skip_empty = TRUE,
       apply_units = TRUE
     ),
+    disturbances_details = shiny::renderUI({
+      tryCatch(
+        {
+          disturbances <- normalized$disturbances
+
+          if (is.null(disturbances) || nrow(disturbances) == 0) {
+            return(htmltools::tags$p("No disturbances recorded"))
+          }
+
+          rows <- lapply(seq_len(nrow(disturbances)), function(i) {
+            row <- disturbances[i, , drop = FALSE]
+
+            type_val <- row$type %|||% "Not recorded"
+            intensity_val <- row$intensity %|||% "Not recorded"
+            comment_val <- row$comment %|||% "Not recorded"
+
+            htmltools::tags$tr(
+              htmltools::tags$td(type_val),
+              htmltools::tags$td(intensity_val),
+              htmltools::tags$td(comment_val)
+            )
+          })
+
+          create_detail_table_with_headers(
+            c("Type", "Intensity", "Comment"),
+            rows,
+            table_style = "width: 100%; table-layout: fixed; word-break: break-word;"
+          )
+        },
+        error = function(e) {
+          message("Error in disturbances_details: ", e$message)
+          htmltools::tags$p(paste("Error processing disturbances:", e$message))
+        }
+      )
+    }),
+    soils_details = shiny::renderUI({
+      tryCatch(
+        {
+          soils <- normalized$soils
+
+          if (is.null(soils) || nrow(soils) == 0) {
+            return(htmltools::tags$p("No soil data recorded"))
+          }
+
+          soil_sections <- lapply(seq_len(nrow(soils)), function(i) {
+            soil <- soils[i, , drop = FALSE]
+            horizon_label <- soil$horizon %|||% "Unknown"
+
+            # Get all non-null fields for this soil
+            fields_to_show <- c(
+              "description", "depth_top", "depth_bottom", "texture", "color",
+              "ph", "organic", "sand", "silt", "clay", "coarse",
+              "exchange_capacity", "base_saturation"
+            )
+
+            htmltools::div(
+              style = "margin-bottom: 1rem;",
+              create_section_header(paste("Horizon:", horizon_label)),
+              format_fields_for_detail_table(
+                fields_to_show,
+                soil,
+                skip_empty = TRUE,
+                apply_units = TRUE
+              )
+            )
+          })
+
+          htmltools::div(soil_sections)
+        },
+        error = function(e) {
+          message("Error in soils_details: ", e$message)
+          htmltools::tags$p(paste("Error processing soils:", e$message))
+        }
+      )
+    }),
     methods_details = render_detail_table(
       c(
         "method_narrative", "placement_method", "cover_method_display", "cover_dispersion",

--- a/R/detail_view.R
+++ b/R/detail_view.R
@@ -135,6 +135,7 @@ show_detail_view <- function(resource_type, vb_code, output, session) {
         },
         "plot-observation" = {
           details <- build_plot_obs_details_view(result)
+          output$plot_notification <- details$plot_notification
           output$plot_header <- details$plot_header
           output$author_code_details <- details$author_code_details
           output$date_details <- details$date_details
@@ -144,9 +145,11 @@ show_detail_view <- function(resource_type, vb_code, output, session) {
           output$methods_details <- details$methods_details
           output$plot_quality_details <- details$plot_quality_details
           output$plot_vegetation_details <- details$plot_vegetation_details
-          output$plot_misc_details <- details$plot_misc_details
           output$taxa_details <- details$taxa_details
           output$communities_details <- details$communities_details
+          output$disturbances_details <- details$disturbances_details
+          output$soils_details <- details$soils_details
+          output$plot_misc_details <- details$plot_misc_details
         },
         "plant-concept" = {
           details <- build_plant_concept_details_view(result)

--- a/R/ui.R
+++ b/R/ui.R
@@ -1300,6 +1300,7 @@ build_detail_overlay <- function() {
         htmltools::tags$div(
           id = "plot-details-cards",
           class = "detail-section",
+          shiny::uiOutput("plot_notification"),
           bslib::card(bslib::card_header("Plot Observation"), shiny::uiOutput("plot_header")),
           bslib::card(bslib::card_header("Author Codes"), shiny::uiOutput("author_code_details")),
           bslib::card(bslib::card_header("Dates"), shiny::uiOutput("date_details")),
@@ -1309,9 +1310,11 @@ build_detail_overlay <- function() {
           bslib::card(bslib::card_header("Methods"), shiny::uiOutput("methods_details")),
           bslib::card(bslib::card_header("Plot Quality"), shiny::uiOutput("plot_quality_details")),
           bslib::card(bslib::card_header("Plot Vegetation"), shiny::uiOutput("plot_vegetation_details")),
-          bslib::card(bslib::card_header("Miscellaneous"), shiny::uiOutput("plot_misc_details")),
           bslib::card(bslib::card_header("Communities"), shiny::uiOutput("communities_details")),
-          bslib::card(bslib::card_header("Taxa Observed"), shiny::uiOutput("taxa_details"))
+          bslib::card(bslib::card_header("Taxa Observed"), shiny::uiOutput("taxa_details")),
+          bslib::card(bslib::card_header("Disturbances"), shiny::uiOutput("disturbances_details")),
+          bslib::card(bslib::card_header("Soils"), shiny::uiOutput("soils_details")),
+          bslib::card(bslib::card_header("Miscellaneous"), shiny::uiOutput("plot_misc_details"))
         ),
 
         # Community Concept Details Cards - wrapped in a div with class for toggling visibility

--- a/R/ui.R
+++ b/R/ui.R
@@ -33,7 +33,9 @@ ui <- function(req) {
     Shiny.addCustomMessageHandler('closeOverlay', function(message) {
       var overlay = document.getElementById('detail-overlay');
       if (overlay) {
-        overlay.style.right = '-400px';
+        // Use responsive close position based on screen width
+        var closePosition = window.innerWidth < 768 ? '-100vw' : '-420px';
+        overlay.style.right = closePosition;
       }
     });
 
@@ -1190,6 +1192,35 @@ custom_theme <- bslib::bs_add_rules(
   #map-loading-overlay.fade-out {
     animation: fadeOut 0.5s ease-out forwards;
   }
+  
+  /* Detail overlay responsive width */
+  #detail-overlay {
+    position: fixed;
+    top: var(--bslib-navbar-height, 57px);
+    height: calc(100vh - var(--bslib-navbar-height, 57px));
+    overflow-y: auto;
+    background: #fff;
+    border-left: 1px solid #ccc;
+    z-index: 1050;
+    padding: 20px;
+    transition: right 0.4s;
+  }
+  
+  /* Mobile: full width */
+  @media (max-width: 767px) {
+    #detail-overlay {
+      right: -100vw;
+      width: 100vw;
+    }
+  }
+  
+  /* Desktop: 420px width */
+  @media (min-width: 768px) {
+    #detail-overlay {
+      right: -420px;
+      width: 420px;
+    }
+  }
 "
 )
 
@@ -1284,13 +1315,11 @@ build_navbar <- function() {
 build_detail_overlay <- function() {
   htmltools::tags$div(
     id = "detail-overlay",
-    style = "position: fixed; top: var(--bslib-navbar-height, 57px); right: -400px; width: 400px; 
-             height: calc(100vh - var(--bslib-navbar-height, 57px)); overflow-y: auto;
-             background: #fff; border-left: 1px solid #ccc; z-index: 1050; padding:20px;
-             transition: right 0.4s;",
     shiny::actionButton("close_overlay", "",
-      onclick = "document.getElementById('detail-overlay').style.right='-400px';
-                            Shiny.setInputValue('close_details', true, {priority:'event'});",
+      onclick = "var overlay = document.getElementById('detail-overlay');
+                 var closePos = window.innerWidth < 768 ? '-100vw' : '-420px';
+                 overlay.style.right = closePos;
+                 Shiny.setInputValue('close_details', true, {priority:'event'});",
       class = "btn-close", style = "float:right; margin-bottom:10px;"
     ),
     shiny::fluidRow(

--- a/inst/shiny/www/display_name_lookup.txt
+++ b/inst/shiny/www/display_name_lookup.txt
@@ -656,3 +656,17 @@ taxoncount,taxon_count,Number of Taxa
 revisions,pl_revisions,Plot Revised
 notespublic,pl_notes_public,Plot Notes Public
 notesmgt,pl_notes_mgt,Plot Notes Management
+horizon,horizon,Horizon
+ph,ph,pH
+organic,organic,Organic Matter
+sand,sand,Sand
+silt,silt,Silt
+clay,clay,Clay
+coarse,coarse,Coarse Fragments
+texture,texture,Texture
+color,color,Color
+depth_top,depth_top,Depth Top
+depth_bottom,depth_bottom,Depth Bottom
+description,description,Description
+exchange_capacity,exchange_capacity,Exchange Capacity
+base_saturation,base_saturation,Base Saturation

--- a/tests/testthat/test_detail_plot.R
+++ b/tests/testthat/test_detail_plot.R
@@ -7,10 +7,10 @@ test_that("build_plot_obs_details_view handles NULL data gracefully", {
   # It should return a list with placeholder components (no plot_header for empty data)
   expect_type(result, "list")
   expect_named(result, c(
-    "plot_header", "author_code_details", "date_details", "location_details", "layout_details",
-    "environmental_details", "methods_details", "plot_quality_details",
-    "plot_vegetation_details", "plot_misc_details",
-    "taxa_details", "communities_details"
+    "plot_notification", "plot_header", "author_code_details", "date_details",
+    "location_details", "layout_details", "environmental_details", "methods_details",
+    "plot_quality_details", "plot_vegetation_details", "communities_details", "taxa_details",
+    "disturbances_details", "soils_details", "plot_misc_details"
   ))
 
   # Each component should be a render function
@@ -23,10 +23,10 @@ test_that("build_plot_obs_details_view formats plot data correctly", {
   # Test structure and types (includes plot_header when data is present)
   expect_type(result, "list")
   expect_named(result, c(
-    "plot_header", "author_code_details", "date_details", "location_details", "layout_details",
-    "environmental_details", "methods_details", "plot_quality_details",
-    "plot_vegetation_details", "plot_misc_details",
-    "taxa_details", "communities_details"
+    "plot_notification", "plot_header", "author_code_details", "date_details",
+    "location_details", "layout_details", "environmental_details", "methods_details",
+    "plot_quality_details", "plot_vegetation_details", "communities_details", "taxa_details",
+    "disturbances_details", "soils_details", "plot_misc_details"
   ))
 
   # Each component should be a render function


### PR DESCRIPTION
## What
Closes #141 by adding a notification to the top of the plot obs detail panel with a link to the updated/replacement observation and closes #144 by adding cards for soils and disturbances to the bottom of the plot obs detail view. Also closes #142 by making the detail panel 5% wider on desktop and full-width on mobile screens.

## Why
So that the web app retains important information from the original vegbank display.

## How

- Created a yellow notification with link when `isTRUE(plot_observation$has_observation_synonym) && has_valid_field_value(plot_observation, "replaced_by_ob_code")` 
- Added a card for disturbances that contains a table with the disturbances type, intensity, and comment, like in old VB
- Added a card for soils that makes a section header labeled with the horizon and a table with all the other non-null fields for each soil observed
- Changed taxa and disturbance table column widths to better fit data
- Change styling in ui.R to make detail panel 420px instead of 400px on desktop and 100vw for screens < 767px wide
- Updated plot detail tests to expect the new notification, soils, and disturbances sections

## Testing and Documentation
All 730 tests pass and check() returns same 3 notes
