### PR TITLE
Feature 177 & 178 dropdown filter for current accepted communities & plants

### DIFF
--- a/R/detail_taxon_obs.R
+++ b/R/detail_taxon_obs.R
@@ -141,12 +141,12 @@ create_taxon_obs_interpretations_ui <- function(taxon_interps) {
           badges <- list(
             if (is_orig) htmltools::tags$span(
               class = "badge rounded-pill me-1",
-              style = "background-color: var(--no-status-bg); color: var(--no-status-text);",
+              style = "background-color: var(--monochrome-bg); color: var(--monochrome-text);",
               "Original"
             ),
             if (is_curr) htmltools::tags$span(
               class = "badge rounded-pill me-1",
-              style = "background-color: var(--accepted-bg); color: var(--accepted-text);",
+              style = "background-color: var(--green-bg); color: var(--green-text);",
               "Current"
             )
           )

--- a/R/server.R
+++ b/R/server.R
@@ -654,7 +654,7 @@ server <- function(input, output, session) {
       concept_type = "community",
       vb_code = vb_code,
       filter_type = filter_type,
-      status = state$community_status  # function ref, not a call — no reactive dependency
+      status_fn = state$community_status
     )
   })
 
@@ -670,7 +670,7 @@ server <- function(input, output, session) {
     # Status changes handled via proxy reload — no dependency here.
     build_concept_table_with_filter(
       concept_type = "plant",
-      status = state$plant_status  # function ref, not a call
+      status_fn = state$plant_status
     )
   })
 

--- a/R/server.R
+++ b/R/server.R
@@ -52,6 +52,7 @@ server <- function(input, output, session) {
     map_request = shiny::reactiveVal(NULL),
     plot_filter = shiny::reactiveVal(NULL), # Cross-resource / citation filter: list(type, code, label)
     community_filter = shiny::reactiveVal(NULL), # Citation filter for cc: list(type, code, label)
+    community_status = shiny::reactiveVal("current_accepted"), # Status filter for community concepts table
     table_states = shiny::reactiveValues(),
     table_sync_pending = shiny::reactiveValues(),
     table_sync_completed_at = shiny::reactiveValues()
@@ -309,7 +310,8 @@ server <- function(input, output, session) {
       highlight_table = state$highlighted_table(),
       highlight_row = state$highlighted_row(),
       plot_filter = state$plot_filter(),
-      community_filter = state$community_filter()
+      community_filter = state$community_filter(),
+      community_status = state$community_status()
     )
 
     url_manager$update_query_string(target_query, mode = mode)
@@ -610,15 +612,18 @@ server <- function(input, output, session) {
   # Download handler for plot table
   output$download_plot_table <- create_table_download_handler("plot_table", input, state, session)
 
-  output$comm_table <- DT::renderDataTable({
-    # Rebuild table when filter changes or status dropdown selection changes
-    filter <- state$community_filter()
-    status_input <- input$comm_status
-    status <- if (!is.null(status_input) && status_input %in% c("any", "current", "accepted", "current_accepted")) {
-      status_input
-    } else {
-      "current_accepted"
+  # Keep state$community_status in sync with the dropdown input
+  shiny::observeEvent(input$comm_status, {
+    val <- input$comm_status
+    if (!is.null(val) && val %in% c("any", "current", "accepted", "current_accepted")) {
+      state$community_status(val)
     }
+  })
+
+  output$comm_table <- DT::renderDataTable({
+    # Rebuild table when filter changes or status changes
+    filter <- state$community_filter()
+    status <- state$community_status()
     vb_code <- if (!is.null(filter)) filter$code else NULL
     filter_type <- if (!is.null(filter)) filter$type else NULL
     build_concept_table_with_filter(
@@ -1246,6 +1251,22 @@ server <- function(input, output, session) {
         # No community filter params in URL, clear filter state
         if (!is.null(state$community_filter())) {
           state$community_filter(NULL)
+        }
+      }
+
+      # Parse and apply community status filter
+      valid_statuses <- c("any", "current", "accepted", "current_accepted")
+      comm_status_param <- url_manager$first_param(params$communities_status)
+      if (!is.null(comm_status_param) && comm_status_param %in% valid_statuses) {
+        if (!identical(state$community_status(), comm_status_param)) {
+          state$community_status(comm_status_param)
+          session$sendCustomMessage("setCommStatus", list(value = comm_status_param))
+        }
+      } else {
+        # Default to current_accepted when not in URL
+        if (!identical(state$community_status(), "current_accepted")) {
+          state$community_status("current_accepted")
+          session$sendCustomMessage("setCommStatus", list(value = "current_accepted"))
         }
       }
 

--- a/R/server.R
+++ b/R/server.R
@@ -617,7 +617,7 @@ server <- function(input, output, session) {
   # Keep state$community_status in sync with the dropdown input
   shiny::observeEvent(input$comm_status, {
     val <- input$comm_status
-    if (!is.null(val) && val %in% c("any", "current", "accepted", "current_accepted")) {
+    if (!is.null(val) && val %in% VALID_CONCEPT_STATUSES) {
       state$community_status(val)
     }
   })
@@ -625,7 +625,7 @@ server <- function(input, output, session) {
   # Keep state$plant_status in sync with the dropdown input
   shiny::observeEvent(input$plant_status, {
     val <- input$plant_status
-    if (!is.null(val) && val %in% c("any", "current", "accepted", "current_accepted")) {
+    if (!is.null(val) && val %in% VALID_CONCEPT_STATUSES) {
       state$plant_status(val)
     }
   })
@@ -1267,36 +1267,18 @@ server <- function(input, output, session) {
         }
       }
 
-      # Parse and apply community status filter
-      valid_statuses <- c("any", "current", "accepted", "current_accepted")
-      comm_status_param <- url_manager$first_param(params$communities_status)
-      if (!is.null(comm_status_param) && comm_status_param %in% valid_statuses) {
-        if (!identical(state$community_status(), comm_status_param)) {
-          state$community_status(comm_status_param)
-          session$sendCustomMessage("setCommStatus", list(value = comm_status_param))
-        }
-      } else {
-        # Default to current_accepted when not in URL
-        if (!identical(state$community_status(), "current_accepted")) {
-          state$community_status("current_accepted")
-          session$sendCustomMessage("setCommStatus", list(value = "current_accepted"))
+      # Restore concept status filters from URL.
+      # `status_reactive` is a reactiveVal — calling it reads, calling it with a value sets.
+      restore_status_param <- function(url_param, status_reactive, msg_type) {
+        val <- url_manager$first_param(url_param)
+        target <- if (!is.null(val) && val %in% VALID_CONCEPT_STATUSES) val else "current_accepted"
+        if (!identical(status_reactive(), target)) {
+          status_reactive(target)
+          session$sendCustomMessage(msg_type, list(value = target))
         }
       }
-
-      # Parse and apply plant status filter
-      plant_status_param <- url_manager$first_param(params$plants_status)
-      if (!is.null(plant_status_param) && plant_status_param %in% valid_statuses) {
-        if (!identical(state$plant_status(), plant_status_param)) {
-          state$plant_status(plant_status_param)
-          session$sendCustomMessage("setPlantStatus", list(value = plant_status_param))
-        }
-      } else {
-        # Default to current_accepted when not in URL
-        if (!identical(state$plant_status(), "current_accepted")) {
-          state$plant_status("current_accepted")
-          session$sendCustomMessage("setPlantStatus", list(value = "current_accepted"))
-        }
-      }
+      restore_status_param(params$communities_status, state$community_status, "setCommStatus")
+      restore_status_param(params$plants_status, state$plant_status, "setPlantStatus")
 
       # Parse and apply map view state
       map_lat_param <- params$map_lat

--- a/R/server.R
+++ b/R/server.R
@@ -53,6 +53,7 @@ server <- function(input, output, session) {
     plot_filter = shiny::reactiveVal(NULL), # Cross-resource / citation filter: list(type, code, label)
     community_filter = shiny::reactiveVal(NULL), # Citation filter for cc: list(type, code, label)
     community_status = shiny::reactiveVal("current_accepted"), # Status filter for community concepts table
+    plant_status = shiny::reactiveVal("current_accepted"), # Status filter for plant concepts table
     table_states = shiny::reactiveValues(),
     table_sync_pending = shiny::reactiveValues(),
     table_sync_completed_at = shiny::reactiveValues()
@@ -311,7 +312,8 @@ server <- function(input, output, session) {
       highlight_row = state$highlighted_row(),
       plot_filter = state$plot_filter(),
       community_filter = state$community_filter(),
-      community_status = state$community_status()
+      community_status = state$community_status(),
+      plant_status = state$plant_status()
     )
 
     url_manager$update_query_string(target_query, mode = mode)
@@ -620,6 +622,14 @@ server <- function(input, output, session) {
     }
   })
 
+  # Keep state$plant_status in sync with the dropdown input
+  shiny::observeEvent(input$plant_status, {
+    val <- input$plant_status
+    if (!is.null(val) && val %in% c("any", "current", "accepted", "current_accepted")) {
+      state$plant_status(val)
+    }
+  })
+
   output$comm_table <- DT::renderDataTable({
     # Rebuild table when filter changes or status changes
     filter <- state$community_filter()
@@ -643,7 +653,10 @@ server <- function(input, output, session) {
   })
 
   output$plant_table <- DT::renderDataTable({
-    build_plant_table()
+    build_concept_table_with_filter(
+      concept_type = "plant",
+      status = state$plant_status()
+    )
   })
 
   output$map <- leaflet::renderLeaflet({
@@ -1267,6 +1280,21 @@ server <- function(input, output, session) {
         if (!identical(state$community_status(), "current_accepted")) {
           state$community_status("current_accepted")
           session$sendCustomMessage("setCommStatus", list(value = "current_accepted"))
+        }
+      }
+
+      # Parse and apply plant status filter
+      plant_status_param <- url_manager$first_param(params$plants_status)
+      if (!is.null(plant_status_param) && plant_status_param %in% valid_statuses) {
+        if (!identical(state$plant_status(), plant_status_param)) {
+          state$plant_status(plant_status_param)
+          session$sendCustomMessage("setPlantStatus", list(value = plant_status_param))
+        }
+      } else {
+        # Default to current_accepted when not in URL
+        if (!identical(state$plant_status(), "current_accepted")) {
+          state$plant_status("current_accepted")
+          session$sendCustomMessage("setPlantStatus", list(value = "current_accepted"))
         }
       }
 

--- a/R/server.R
+++ b/R/server.R
@@ -630,17 +630,31 @@ server <- function(input, output, session) {
     }
   })
 
+  # Proxies for status filter reloads. When status changes we do a tbody-only
+  # ajax.reload() so the DT wrapper DOM (including initComplete-injected elements)
+  # is never destroyed.
+  comm_proxy  <- DT::dataTableProxy("comm_table",  session = session)
+  plant_proxy <- DT::dataTableProxy("plant_table", session = session)
+
+  shiny::observeEvent(state$community_status(), {
+    DT::reloadData(comm_proxy, resetPaging = TRUE)
+  }, ignoreInit = TRUE)
+
+  shiny::observeEvent(state$plant_status(), {
+    DT::reloadData(plant_proxy, resetPaging = TRUE)
+  }, ignoreInit = TRUE)
+
   output$comm_table <- DT::renderDataTable({
-    # Rebuild table when filter changes or status changes
+    # Rebuild table when citation filter changes.
+    # Status changes are handled via proxy reload above — no dependency here.
     filter <- state$community_filter()
-    status <- state$community_status()
     vb_code <- if (!is.null(filter)) filter$code else NULL
     filter_type <- if (!is.null(filter)) filter$type else NULL
     build_concept_table_with_filter(
       concept_type = "community",
       vb_code = vb_code,
       filter_type = filter_type,
-      status = status
+      status = state$community_status  # function ref, not a call — no reactive dependency
     )
   })
 
@@ -653,9 +667,10 @@ server <- function(input, output, session) {
   })
 
   output$plant_table <- DT::renderDataTable({
+    # Status changes handled via proxy reload — no dependency here.
     build_concept_table_with_filter(
       concept_type = "plant",
-      status = state$plant_status()
+      status = state$plant_status  # function ref, not a call
     )
   })
 

--- a/R/server.R
+++ b/R/server.R
@@ -611,11 +611,22 @@ server <- function(input, output, session) {
   output$download_plot_table <- create_table_download_handler("plot_table", input, state, session)
 
   output$comm_table <- DT::renderDataTable({
-    # Rebuild table when filter changes for citation filtering
+    # Rebuild table when filter changes or status dropdown selection changes
     filter <- state$community_filter()
+    status_input <- input$comm_status
+    status <- if (!is.null(status_input) && status_input %in% c("any", "current", "accepted", "current_accepted")) {
+      status_input
+    } else {
+      "current_accepted"
+    }
     vb_code <- if (!is.null(filter)) filter$code else NULL
     filter_type <- if (!is.null(filter)) filter$type else NULL
-    build_concept_table_with_filter(concept_type = "community", vb_code = vb_code, filter_type = filter_type)
+    build_concept_table_with_filter(
+      concept_type = "community",
+      vb_code = vb_code,
+      filter_type = filter_type,
+      status = status
+    )
   })
 
   output$proj_table <- DT::renderDataTable({

--- a/R/table.R
+++ b/R/table.R
@@ -236,7 +236,7 @@ create_status_badges <- function(status, stop_date) {
     (length(status) == 1 && is.na(status))
 
   if (status_na) {
-    return('<span class="badge rounded-pill" style="background-color: var(--no-status-bg); color: var(--no-status-text);">No Status</span>')
+    return('<span class="badge rounded-pill" style="background-color: var(--monochrome-bg); color: var(--monochrome-text);">No Status</span>')
   }
 
   is_accepted <- startsWith(tolower(status), "accepted")
@@ -250,10 +250,10 @@ create_status_badges <- function(status, stop_date) {
     )
 
   green_badge <- function(label) {
-    sprintf('<span class="badge rounded-pill" style="background-color: var(--accepted-bg); color: var(--accepted-text);">%s</span>', label)
+    sprintf('<span class="badge rounded-pill" style="background-color: var(--green-bg); color: var(--green-text);">%s</span>', label)
   }
   yellow_badge <- function(label) {
-    sprintf('<span class="badge rounded-pill" style="background-color: var(--not-current-bg); color: var(--not-current-text);">%s</span>', label)
+    sprintf('<span class="badge rounded-pill" style="background-color: var(--yellow-bg); color: var(--yellow-text);">%s</span>', label)
   }
 
   if (is_accepted && is_current) {

--- a/R/table.R
+++ b/R/table.R
@@ -216,18 +216,54 @@ create_all_obs_count_links <- function(obs_counts, entity_codes, entity_labels) 
   }, character(1))
 }
 
-#' Create a status badge for concept status
+#' Create status badges for a concept row
 #'
-#' @param status Logical or NA; TRUE for accepted, FALSE for not accepted, NA for unknown
-#' @return HTML string for the badge
+#' Produces one or two badge spans reflecting both acceptance status and
+#' currency independently, mirroring the API filter semantics:
+#' \itemize{
+#'   \item{accepted: \code{status starts with "accepted"} (case-insensitive)}
+#'   \item{current: \code{stop_date} is NA, blank, or a date in the future}
+#' }
+#'
+#' @param status Character; the concept's status value (e.g. "accepted",
+#'   "undetermined", \code{NA})
+#' @param stop_date Character or NA; the concept's stop_date from the API
+#'   (\code{NA}, blank, or a future date means still active / current)
+#' @return HTML string with one or two badge \code{<span>} elements
 #' @noRd
-create_status_badge <- function(status) {
-  if (is.null(status) || identical(status, "") || is.na(status)) {
-    '<span class="badge rounded-pill" style="background-color: var(--no-status-bg); color: var(--no-status-text);">No Status</span>'
-  } else if (isTRUE(status) || identical(status, "true") || identical(status, "TRUE")) {
-    '<span class="badge rounded-pill" style="background-color: var(--accepted-bg); color: var(--accepted-text);">Accepted</span>'
+create_status_badges <- function(status, stop_date) {
+  status_na <- is.null(status) || identical(status, "") ||
+    (length(status) == 1 && is.na(status))
+
+  if (status_na) {
+    return('<span class="badge rounded-pill" style="background-color: var(--no-status-bg); color: var(--no-status-text);">No Status</span>')
+  }
+
+  is_accepted <- startsWith(tolower(status), "accepted")
+  is_current <- is.null(stop_date) || identical(stop_date, "") ||
+    (length(stop_date) == 1 && is.na(stop_date)) ||
+    tryCatch(
+      !is.na(stop_date) && as.POSIXct(stop_date, tryFormats = c(
+        "%a, %d %b %Y %H:%M:%S GMT", "%Y-%m-%d"
+      ), tz = "UTC") > Sys.time(),
+      error = function(e) FALSE
+    )
+
+  green_badge <- function(label) {
+    sprintf('<span class="badge rounded-pill" style="background-color: var(--accepted-bg); color: var(--accepted-text);">%s</span>', label)
+  }
+  yellow_badge <- function(label) {
+    sprintf('<span class="badge rounded-pill" style="background-color: var(--not-current-bg); color: var(--not-current-text);">%s</span>', label)
+  }
+
+  if (is_accepted && is_current) {
+    green_badge("Currently Accepted")
+  } else if (is_accepted) {
+    paste0(green_badge("Accepted"), yellow_badge("Not Current"))
+  } else if (is_current) {
+    paste0(yellow_badge("Not Accepted"), green_badge("Current"))
   } else {
-    '<span class="badge rounded-pill" style="background-color: var(--not-current-bg); color: var(--not-current-text);">Not Current</span>'
+    paste0(yellow_badge("Not Accepted"), yellow_badge("Not Current"))
   }
 }
 

--- a/R/table.R
+++ b/R/table.R
@@ -259,11 +259,11 @@ create_status_badges <- function(status, stop_date) {
   if (is_accepted && is_current) {
     green_badge("Currently Accepted")
   } else if (is_accepted) {
-    paste0(green_badge("Accepted"), yellow_badge("Not Current"))
+    paste(green_badge("Accepted"), yellow_badge("Not Current"))
   } else if (is_current) {
-    paste0(yellow_badge("Not Accepted"), green_badge("Current"))
+    paste(yellow_badge("Not Accepted"), green_badge("Current"))
   } else {
-    paste0(yellow_badge("Not Accepted"), yellow_badge("Not Current"))
+    paste(yellow_badge("Not Accepted"), yellow_badge("Not Current"))
   }
 }
 

--- a/R/table.R
+++ b/R/table.R
@@ -224,6 +224,8 @@ create_all_obs_count_links <- function(obs_counts, entity_codes, entity_labels) 
 #'   \item{accepted: \code{status starts with "accepted"} (case-insensitive)}
 #'   \item{current: \code{stop_date} is NA, blank, or a date in the future}
 #' }
+#' Uses sprintf and paste because htmltools have too much overhead and cause
+#' the tables to load slower when we do this for each row in a large dataset.
 #'
 #' @param status Character; the concept's status value (e.g. "accepted",
 #'   "undetermined", \code{NA})
@@ -242,12 +244,12 @@ create_status_badges <- function(status, stop_date) {
   is_accepted <- startsWith(tolower(status), "accepted")
   is_current <- is.null(stop_date) || identical(stop_date, "") ||
     (length(stop_date) == 1 && is.na(stop_date)) ||
-    tryCatch(
-      !is.na(stop_date) && as.POSIXct(stop_date, tryFormats = c(
+    tryCatch({
+      parsed_stop <- suppressWarnings(as.POSIXct(stop_date, tryFormats = c(
         "%a, %d %b %Y %H:%M:%S GMT", "%Y-%m-%d"
-      ), tz = "UTC") > Sys.time(),
-      error = function(e) FALSE
-    )
+      ), tz = "UTC"))
+      !is.na(parsed_stop) && parsed_stop > Sys.time()
+    }, error = function(e) FALSE)
 
   green_badge <- function(label) {
     sprintf('<span class="badge rounded-pill" style="background-color: var(--green-bg); color: var(--green-text);">%s</span>', label)

--- a/R/table_concept.R
+++ b/R/table_concept.R
@@ -95,11 +95,17 @@ build_concept_table_with_filter <- function(concept_type = c("plant", "community
     stop("No concept table spec registered for type: ", concept_type)
   }
 
-  # Inject status filter query param (e.g. "current_accepted" or "any")
+  # Inject status filter query param. Supports a reactive function (called per AJAX
+  # request) or a plain scalar (used once at render time).
   if (!is.null(status)) {
+    status_query <- if (is.function(status)) {
+      function() list(status = shiny::isolate(status()))
+    } else {
+      list(status = status)
+    }
     spec$data_source <- utils::modifyList(
       spec$data_source %||% list(),
-      list(query = list(status = status))
+      list(query = status_query)
     )
   }
 
@@ -405,16 +411,12 @@ CONCEPT_TABLE_SPECS <- local({
           if (config$concept_type == "plant") .PLANT_TABLE_HELP_CONTENT else .COMMUNITY_TABLE_HELP_CONTENT
         )
         opts <- list(dom = "Bfrtip", buttons = I(list(help_btn)))
-        if (config$concept_type == "community") {
-          opts$initComplete <- DT::JS(
-            "function(settings) { if (window.vbSetupCommStatusDropdown) window.vbSetupCommStatusDropdown(settings.nTableWrapper); }"
-          )
-        }
-        if (config$concept_type == "plant") {
-          opts$initComplete <- DT::JS(
-            "function(settings) { if (window.vbSetupPlantStatusDropdown) window.vbSetupPlantStatusDropdown(settings.nTableWrapper); }"
-          )
-        }
+        opts$initComplete <- DT::JS(paste0(
+          "function(settings) {",
+          "var id = $(settings.nTable).closest('.datatables')[0].id;",
+          "if (window.vbConceptStatusInit) window.vbConceptStatusInit(settings.nTableWrapper, id);",
+          "}"
+        ))
         opts
       }),
       datatable_args = list(extensions = "Buttons"),

--- a/R/table_concept.R
+++ b/R/table_concept.R
@@ -2,6 +2,10 @@
 #'
 #' Provides server-side DataTable builders for plant and community concepts.
 #' @noRd
+
+# Valid values for the concept status filter, shared between server logic and URL restore.
+VALID_CONCEPT_STATUSES <- c("any", "current", "accepted", "current_accepted")
+
 CONCEPT_CONFIG <- list(
   plant = build_table_module_config(
     type = "plant",

--- a/R/table_concept.R
+++ b/R/table_concept.R
@@ -346,10 +346,6 @@ get_concept_config <- function(concept_type) {
   gsub("'", "\\'", html, fixed = TRUE)
 })
 
-#' Build a DT Buttons JS definition for the "Show archival data" toggle.
-#'
-#' When active, sets `window.vbCommShowArchival = true` and fires the Shiny
-#' input `comm_show_archival` so the server can rebuild the table with
 .COMMUNITY_TABLE_HELP_CONTENT <- local({
   html <- as.character(htmltools::tagList(
     htmltools::tags$p("This table lists vegetation community concepts in VegBank's classification hierarchy. Each row is a single community type."),

--- a/R/table_concept.R
+++ b/R/table_concept.R
@@ -12,12 +12,13 @@ CONCEPT_CONFIG <- list(
     fields = c(
       "pc_code",
       "plant_name",
-      "current_accepted",
       "plant_level",
       "concept_rf_code",
       "concept_rf_label",
       "obs_count",
-      "plant_description"
+      "plant_description",
+      "status",
+      "stop_date"
     ),
     extra = list(
       concept_type = "plant",
@@ -37,12 +38,13 @@ CONCEPT_CONFIG <- list(
     fields = c(
       "cc_code",
       "comm_name",
-      "current_accepted",
       "comm_level",
       "concept_rf_code",
       "concept_rf_label",
       "obs_count",
-      "comm_description"
+      "comm_description",
+      "status",
+      "stop_date"
     ),
     extra = list(
       concept_type = "community",
@@ -178,7 +180,8 @@ process_concept_data <- function(data_sources, concept_type = "plant") {
   display_names <- clean_column_data(concept_data, config$name_field)
   concept_codes <- concept_data[[config$code_field]]
 
-  statuses <- concept_data$current_accepted
+  raw_status   <- concept_data$status
+  raw_stopdate <- concept_data$stop_date
   levels <- clean_column_data(concept_data, config$level_field)
   reference_codes <- concept_data$concept_rf_code
   reference_names <- clean_column_data(concept_data, "concept_rf_label")
@@ -210,7 +213,11 @@ process_concept_data <- function(data_sources, concept_type = "plant") {
     }
   }, character(1))
 
-  status_badges <- vapply(statuses, create_status_badge, character(1))
+  status_badges <- vapply(
+    seq_along(raw_status),
+    function(i) create_status_badges(raw_status[[i]], raw_stopdate[[i]]),
+    character(1)
+  )
 
   result <- data.frame(
     Actions = actions,

--- a/R/table_concept.R
+++ b/R/table_concept.R
@@ -406,6 +406,11 @@ CONCEPT_TABLE_SPECS <- local({
             "function(settings) { if (window.vbSetupCommStatusDropdown) window.vbSetupCommStatusDropdown(settings.nTableWrapper); }"
           )
         }
+        if (config$concept_type == "plant") {
+          opts$initComplete <- DT::JS(
+            "function(settings) { if (window.vbSetupPlantStatusDropdown) window.vbSetupPlantStatusDropdown(settings.nTableWrapper); }"
+          )
+        }
         opts
       }),
       datatable_args = list(extensions = "Buttons"),

--- a/R/table_concept.R
+++ b/R/table_concept.R
@@ -79,13 +79,22 @@ build_concept_table <- function(concept_type = c("plant", "community")) {
 #' @param filter_type Optional filter type ("single-entity-citation")
 #' @return A DT::datatable object
 #' @noRd
-build_concept_table_with_filter <- function(concept_type = c("plant", "community"), 
-                                            vb_code = NULL, 
-                                            filter_type = NULL) {
+build_concept_table_with_filter <- function(concept_type = c("plant", "community"),
+                                            vb_code = NULL,
+                                            filter_type = NULL,
+                                            status = NULL) {
   concept_type <- match.arg(concept_type)
   spec <- CONCEPT_TABLE_SPECS[[concept_type]]
   if (is.null(spec)) {
     stop("No concept table spec registered for type: ", concept_type)
+  }
+
+  # Inject status filter query param (e.g. "current_accepted" or "any")
+  if (!is.null(status)) {
+    spec$data_source <- utils::modifyList(
+      spec$data_source %||% list(),
+      list(query = list(status = status))
+    )
   }
 
   has_filter <- !is.null(vb_code) && !is.na(vb_code) && nzchar(vb_code)
@@ -324,6 +333,10 @@ get_concept_config <- function(concept_type) {
   gsub("'", "\\'", html, fixed = TRUE)
 })
 
+#' Build a DT Buttons JS definition for the "Show archival data" toggle.
+#'
+#' When active, sets `window.vbCommShowArchival = true` and fires the Shiny
+#' input `comm_show_archival` so the server can rebuild the table with
 .COMMUNITY_TABLE_HELP_CONTENT <- local({
   html <- as.character(htmltools::tagList(
     htmltools::tags$p("This table lists vegetation community concepts in VegBank's classification hierarchy. Each row is a single community type."),
@@ -375,13 +388,19 @@ CONCEPT_TABLE_SPECS <- local({
       } else {
         "by community name, code, VegBank code, or description\u2026"
       },
-      options = list(
-        dom = "Bfrtip",
-        buttons = I(list(make_help_button_js(
+      options = local({
+        help_btn <- make_help_button_js(
           if (config$concept_type == "plant") "Plants Table" else "Communities Table",
           if (config$concept_type == "plant") .PLANT_TABLE_HELP_CONTENT else .COMMUNITY_TABLE_HELP_CONTENT
-        )))
-      ),
+        )
+        opts <- list(dom = "Bfrtip", buttons = I(list(help_btn)))
+        if (config$concept_type == "community") {
+          opts$initComplete <- DT::JS(
+            "function(settings) { if (window.vbSetupCommStatusDropdown) window.vbSetupCommStatusDropdown(settings.nTableWrapper); }"
+          )
+        }
+        opts
+      }),
       datatable_args = list(extensions = "Buttons"),
       initial_display = process_concept_data(schema_template, concept_type = config$concept_type)
     )

--- a/R/table_concept.R
+++ b/R/table_concept.R
@@ -88,24 +88,20 @@ build_concept_table <- function(concept_type = c("plant", "community")) {
 build_concept_table_with_filter <- function(concept_type = c("plant", "community"),
                                             vb_code = NULL,
                                             filter_type = NULL,
-                                            status = NULL) {
+                                            status_fn = NULL) {
   concept_type <- match.arg(concept_type)
   spec <- CONCEPT_TABLE_SPECS[[concept_type]]
   if (is.null(spec)) {
     stop("No concept table spec registered for type: ", concept_type)
   }
 
-  # Inject status filter query param. Supports a reactive function (called per AJAX
-  # request) or a plain scalar (used once at render time).
-  if (!is.null(status)) {
-    status_query <- if (is.function(status)) {
-      function() list(status = shiny::isolate(status()))
-    } else {
-      list(status = status)
-    }
+  # Inject status as a query function evaluated per AJAX request via shiny::isolate().
+  # Always a zero-argument function so the AJAX handler reads the current value at
+  # draw time without creating a reactive dependency inside renderDataTable.
+  if (!is.null(status_fn)) {
     spec$data_source <- utils::modifyList(
       spec$data_source %||% list(),
-      list(query = status_query)
+      list(query = function() list(status = shiny::isolate(status_fn())))
     )
   }
 

--- a/R/ui.R
+++ b/R/ui.R
@@ -65,7 +65,8 @@ ui <- function(req) {
     "// Application constants - single source of truth from R\n",
     "window.DOWNLOAD_MAX_RECORDS = ", DOWNLOAD_MAX_RECORDS, ";\n",
     "window.DETAIL_TYPE_LABELS = {\n", detail_labels_js, "\n};\n",
-    "window.DETAIL_ICONS = ", jsonlite::toJSON(DETAIL_ICONS, auto_unbox = TRUE), ";\n"
+    "window.DETAIL_ICONS = ", jsonlite::toJSON(DETAIL_ICONS, auto_unbox = TRUE), ";\n",
+    "window.VB_VALID_CONCEPT_STATUSES = ", jsonlite::toJSON(VALID_CONCEPT_STATUSES), ";\n"
   )))
 
   # External JavaScript file with main application logic

--- a/R/url_state_manager.R
+++ b/R/url_state_manager.R
@@ -289,6 +289,9 @@ URLStateManager <- R6::R6Class(
       length <- self$parse_numeric_param(params[[paste0(prefix, "_length")]])
       order <- self$deserialize_order_from_query(params[[paste0(prefix, "_order")]])
       search <- self$first_param(params[[paste0(prefix, "_search")]]) %||% ""
+      status <- if (identical(key, "communities")) {
+        self$first_param(params["communities_status"])
+      } else NULL
 
       if (is.null(start) && is.null(length) && is.null(order) && !nzchar(search)) {
         return(NULL)
@@ -345,7 +348,8 @@ URLStateManager <- R6::R6Class(
                                   map_lat = NULL, map_lng = NULL, map_zoom = NULL,
                                   map_has_custom_state = FALSE, table_states = list(),
                                   highlight_table = NULL, highlight_row = NULL,
-                                  plot_filter = NULL, community_filter = NULL) {
+                                  plot_filter = NULL, community_filter = NULL,
+                                  community_status = NULL) {
       if (is.null(tab) || !nzchar(tab)) {
         tab <- "Overview"
       }
@@ -391,6 +395,12 @@ URLStateManager <- R6::R6Class(
         if (!is.null(community_filter$label) && nzchar(community_filter$label)) {
           params$comm_filter_label <- community_filter$label
         }
+      }
+
+      # Include community status filter (omit when it's the default)
+      if (!is.null(community_status) && nzchar(community_status) &&
+          !identical(community_status, "current_accepted")) {
+        params$communities_status <- community_status
       }
 
       include_map_params <- identical(tab, "Map") || isTRUE(map_has_custom_state)

--- a/R/url_state_manager.R
+++ b/R/url_state_manager.R
@@ -349,7 +349,7 @@ URLStateManager <- R6::R6Class(
                                   map_has_custom_state = FALSE, table_states = list(),
                                   highlight_table = NULL, highlight_row = NULL,
                                   plot_filter = NULL, community_filter = NULL,
-                                  community_status = NULL) {
+                                  community_status = NULL, plant_status = NULL) {
       if (is.null(tab) || !nzchar(tab)) {
         tab <- "Overview"
       }
@@ -401,6 +401,12 @@ URLStateManager <- R6::R6Class(
       if (!is.null(community_status) && nzchar(community_status) &&
           !identical(community_status, "current_accepted")) {
         params$communities_status <- community_status
+      }
+
+      # Include plant status filter (omit when it's the default)
+      if (!is.null(plant_status) && nzchar(plant_status) &&
+          !identical(plant_status, "current_accepted")) {
+        params$plants_status <- plant_status
       }
 
       include_map_params <- identical(tab, "Map") || isTRUE(map_has_custom_state)

--- a/R/url_state_manager.R
+++ b/R/url_state_manager.R
@@ -289,9 +289,6 @@ URLStateManager <- R6::R6Class(
       length <- self$parse_numeric_param(params[[paste0(prefix, "_length")]])
       order <- self$deserialize_order_from_query(params[[paste0(prefix, "_order")]])
       search <- self$first_param(params[[paste0(prefix, "_search")]]) %||% ""
-      status <- if (identical(key, "communities")) {
-        self$first_param(params["communities_status"])
-      } else NULL
 
       if (is.null(start) && is.null(length) && is.null(order) && !nzchar(search)) {
         return(NULL)

--- a/inst/shiny/www/vegbank_app.js
+++ b/inst/shiny/www/vegbank_app.js
@@ -488,8 +488,8 @@ window.vbMapBindShinyInputs = function(map, el) {
 // The selected value is persisted in the URL as `communities_status` and
 // restored on page reload via window.vbCommStatus (set by setCommStatus handler).
 window.vbSetupCommStatusDropdown = function(nTableWrapper) {
-  var btnBar = $(nTableWrapper).find('.dt-buttons');
-  if (!btnBar.length || btnBar.find('.vb-status-select-wrapper').length) return;
+  var $filter = $(nTableWrapper).find('.dataTables_filter');
+  if (!$filter.length || $(nTableWrapper).find('.vb-status-select-wrapper').length) return;
   // Prefer the in-memory value (set by setCommStatus on URL restore) over the URL
   // directly, to stay in sync with what the server has already applied.
   var urlParams = new URLSearchParams(window.location.search);
@@ -500,7 +500,7 @@ window.vbSetupCommStatusDropdown = function(nTableWrapper) {
     : (urlStatus && validStatuses.indexOf(urlStatus) !== -1 ? urlStatus : 'current_accepted');
   var $wrapper = $('<label class="vb-status-select-wrapper">' +
     '<span class="vb-status-select-label">Status:</span>' +
-    '<select class="vb-status-select">' +
+    '<select class="vb-comm-status-select vb-status-select">' +
       '<option value="current_accepted">Currently Accepted</option>' +
       '<option value="current">Current</option>' +
       '<option value="accepted">Accepted</option>' +
@@ -508,7 +508,7 @@ window.vbSetupCommStatusDropdown = function(nTableWrapper) {
     '</select>' +
     '</label>');
   $wrapper.find('select').val(currentVal);
-  btnBar.append($wrapper);
+  $filter.after($wrapper);
   $wrapper.find('select').on('change', function() {
     window.vbCommStatus = this.value;
     // Write communities_status to the URL and reset pagination before Shiny rebuilds.
@@ -533,38 +533,54 @@ Shiny.addCustomMessageHandler('setCommStatus', function(message) {
   var val = message.value;
   window.vbCommStatus = val;
   // Update any rendered dropdown immediately
-  $('.vb-status-select').val(val);
+  $('.vb-comm-status-select').val(val);
 });
 
-// Help/instructions button control — adds a square info button above the zoom controls
-// (top-left) that opens a Bootstrap popover with usage instructions.
-window.vbMapHelpControl = function(map, el, btnInnerHtml, closeIconHtml, contentHtml) {
-  var helpBtn = null;
-  var helpControl = L.control({position: 'topleft'});
-  helpControl.onAdd = function() {
-    var container = L.DomUtil.create('div', 'leaflet-bar leaflet-control vb-map-help-control');
-    helpBtn = L.DomUtil.create('a', 'vb-map-help-btn vb-help-btn', container);
-    helpBtn.href = '#';
-    helpBtn.setAttribute('role', 'button');
-    helpBtn.setAttribute('title', 'About this map');
-    helpBtn.setAttribute('aria-label', 'About this map');
-    helpBtn.innerHTML = btnInnerHtml;
-    L.DomEvent.disableClickPropagation(container);
-    L.DomEvent.on(helpBtn, 'click', L.DomEvent.preventDefault);
-    return container;
-  };
-  helpControl.addTo(map);
-
-  // Move the help control to the top of the top-left stack (above zoom +/-)
-  var topLeft = el.querySelector('.leaflet-top.leaflet-left');
-  if (topLeft && topLeft.children.length > 1) {
-    topLeft.insertBefore(topLeft.lastElementChild, topLeft.firstElementChild);
-  }
-
-  if (helpBtn && window.vbHelpButton) {
-    window.vbHelpButton(helpBtn, '<strong>Map</strong>', contentHtml, closeIconHtml);
-  }
+// Set up the status filter dropdown in the Plants table toolbar.
+window.vbSetupPlantStatusDropdown = function(nTableWrapper) {
+  var $filter = $(nTableWrapper).find('.dataTables_filter');
+  if (!$filter.length || $(nTableWrapper).find('.vb-status-select-wrapper').length) return;
+  var urlParams = new URLSearchParams(window.location.search);
+  var validStatuses = ['current_accepted', 'current', 'accepted', 'any'];
+  var urlStatus = urlParams.get('plants_status');
+  var currentVal = (window.vbPlantStatus && validStatuses.indexOf(window.vbPlantStatus) !== -1)
+    ? window.vbPlantStatus
+    : (urlStatus && validStatuses.indexOf(urlStatus) !== -1 ? urlStatus : 'current_accepted');
+  var $wrapper = $('<label class="vb-status-select-wrapper">' +
+    '<span class="vb-status-select-label">Status:</span>' +
+    '<select class="vb-plant-status-select vb-status-select">' +
+      '<option value="current_accepted">Currently Accepted</option>' +
+      '<option value="current">Current</option>' +
+      '<option value="accepted">Accepted</option>' +
+      '<option value="any">Any</option>' +
+    '</select>' +
+    '</label>');
+  $wrapper.find('select').val(currentVal);
+  $filter.after($wrapper);
+  $wrapper.find('select').on('change', function() {
+    window.vbPlantStatus = this.value;
+    var params = new URLSearchParams(window.location.search);
+    if (this.value === 'current_accepted') {
+      params.delete('plants_status');
+    } else {
+      params.set('plants_status', this.value);
+    }
+    if (params.has('plants_start')) {
+      params.set('plants_start', '0');
+    }
+    var newSearch = params.toString();
+    history.replaceState(null, '', newSearch ? '?' + newSearch : window.location.pathname);
+    Shiny.setInputValue('plant_status', this.value, {priority: 'event'});
+  });
 };
+
+// Receive the current plants status from the server (e.g. on URL restore)
+// and update the dropdown to match without triggering a redundant Shiny input.
+Shiny.addCustomMessageHandler('setPlantStatus', function(message) {
+  var val = message.value;
+  window.vbPlantStatus = val;
+  $('.vb-plant-status-select').val(val);
+});
 
 // Shared helper — set up a toggleable info popover on a DT help button.
 // Called from each table's DT button init callback.

--- a/inst/shiny/www/vegbank_app.js
+++ b/inst/shiny/www/vegbank_app.js
@@ -482,68 +482,49 @@ window.vbMapBindShinyInputs = function(map, el) {
   });
 };
 
-// Shared factory for the concept status dropdown.
-// Injected via each table's initComplete callback, just to the left of the search bar.
-// config: { urlKey, windowVar, cssClass, shinyInput, paginationKey }
-function vbSetupConceptStatusDropdown(nTableWrapper, config) {
-  var $filter = $(nTableWrapper).find('.dataTables_filter');
-  if (!$filter.length || $(nTableWrapper).find('.vb-status-select-wrapper').length) return;
-  // Prefer the in-memory value (set by the server on URL restore) over the raw URL param
-  // so the dropdown always reflects what the server has already applied.
+// Inject the status <label> into the .dataTables_filter area on table init.
+// Called from each concept table's initComplete callback. Uses the Shiny
+// output div id (same resolution as registerDataTableMapping) to look up config.
+var vbConceptStatusConfigs = {
+  plant_table: { urlKey: 'plants_status',      windowVar: 'vbPlantStatus', cssClass: 'vb-plant-status-select', shinyInput: 'plant_status', paginationKey: 'plants_start' },
+  comm_table:  { urlKey: 'communities_status', windowVar: 'vbCommStatus',  cssClass: 'vb-comm-status-select',  shinyInput: 'comm_status',  paginationKey: 'communities_start' }
+};
+
+window.vbConceptStatusInit = function(nTableWrapper, tableId) {
+  var config = vbConceptStatusConfigs[tableId];
+  if (!config) return;
   var validStatuses = ['current_accepted', 'current', 'accepted', 'any'];
-  var urlStatus = new URLSearchParams(window.location.search).get(config.urlKey);
+  var urlVal    = new URLSearchParams(window.location.search).get(config.urlKey);
   var storedVal = window[config.windowVar];
-  var currentVal = (storedVal && validStatuses.indexOf(storedVal) !== -1)
+  var initVal   = (storedVal && validStatuses.indexOf(storedVal) !== -1)
     ? storedVal
-    : (urlStatus && validStatuses.indexOf(urlStatus) !== -1 ? urlStatus : 'current_accepted');
-  var $wrapper = $('<label class="vb-status-select-wrapper">' +
-    '<span class="vb-status-select-label">Status:</span>' +
-    '<select class="' + config.cssClass + ' vb-status-select">' +
-      '<option value="current_accepted">Currently Accepted</option>' +
-      '<option value="current">Current</option>' +
-      '<option value="accepted">Accepted</option>' +
-      '<option value="any">Any</option>' +
-    '</select>' +
-    '</label>');
-  $wrapper.find('select').val(currentVal);
-  $filter.after($wrapper);
-  $wrapper.find('select').on('change', function() {
-    window[config.windowVar] = this.value;
+    : (urlVal && validStatuses.indexOf(urlVal) !== -1 ? urlVal : 'current_accepted');
+  var $label = $(
+    '<label class="vb-status-label">' +
+      'Status:' +
+      '<select class="' + config.cssClass + ' vb-status-select">' +
+        '<option value="current_accepted">Currently Accepted</option>' +
+        '<option value="current">Current</option>' +
+        '<option value="accepted">Accepted</option>' +
+        '<option value="any">Any</option>' +
+      '</select>' +
+    '</label>'
+  );
+  $label.find('select').val(initVal);
+  $(nTableWrapper).find('.dataTables_filter').after($label[0]);
+  $label.find('select').on('change', function() {
+    var val = this.value;
+    window[config.windowVar] = val;
     var params = new URLSearchParams(window.location.search);
-    if (this.value === 'current_accepted') {
-      params.delete(config.urlKey);
-    } else {
-      params.set(config.urlKey, this.value);
-    }
-    if (params.has(config.paginationKey)) {
-      params.set(config.paginationKey, '0');
-    }
+    if (val === 'current_accepted') { params.delete(config.urlKey); } else { params.set(config.urlKey, val); }
+    if (params.has(config.paginationKey)) { params.set(config.paginationKey, '0'); }
     var newSearch = params.toString();
     history.replaceState(null, '', newSearch ? '?' + newSearch : window.location.pathname);
-    Shiny.setInputValue(config.shinyInput, this.value, {priority: 'event'});
-  });
-}
-
-window.vbSetupCommStatusDropdown = function(nTableWrapper) {
-  vbSetupConceptStatusDropdown(nTableWrapper, {
-    urlKey: 'communities_status',
-    windowVar: 'vbCommStatus',
-    cssClass: 'vb-comm-status-select',
-    shinyInput: 'comm_status',
-    paginationKey: 'communities_start'
+    Shiny.setInputValue(config.shinyInput, val, {priority: 'event'});
   });
 };
 
-window.vbSetupPlantStatusDropdown = function(nTableWrapper) {
-  vbSetupConceptStatusDropdown(nTableWrapper, {
-    urlKey: 'plants_status',
-    windowVar: 'vbPlantStatus',
-    cssClass: 'vb-plant-status-select',
-    shinyInput: 'plant_status',
-    paginationKey: 'plants_start'
-  });
-};
-
+// Update the status select when the server restores the value from URL.
 Shiny.addCustomMessageHandler('setCommStatus', function(message) {
   window.vbCommStatus = message.value;
   $('.vb-comm-status-select').val(message.value);

--- a/inst/shiny/www/vegbank_app.js
+++ b/inst/shiny/www/vegbank_app.js
@@ -503,6 +503,14 @@ window.vbSetupCommStatusDropdown = function(nTableWrapper) {
   btnBar.append($wrapper);
   $wrapper.find('select').on('change', function() {
     window.vbCommStatus = this.value;
+    // Reset communities_start to 0 in the URL so that when Shiny rebuilds the
+    // table and vegbankLoadTableState re-reads the URL during init, it starts
+    // at page 1 instead of a potentially out-of-range offset.
+    var params = new URLSearchParams(window.location.search);
+    if (params.has('communities_start')) {
+      params.set('communities_start', '0');
+      history.replaceState(null, '', '?' + params.toString());
+    }
     Shiny.setInputValue('comm_status', this.value, {priority: 'event'});
   });
 };

--- a/inst/shiny/www/vegbank_app.js
+++ b/inst/shiny/www/vegbank_app.js
@@ -493,7 +493,7 @@ window.vbSetupCommStatusDropdown = function(nTableWrapper) {
   var $wrapper = $('<label class="vb-status-select-wrapper">' +
     '<span class="vb-status-select-label">Status:</span>' +
     '<select class="vb-status-select">' +
-      '<option value="current_accepted">Current &amp; Accepted</option>' +
+      '<option value="current_accepted">Currently Accepted</option>' +
       '<option value="current">Current</option>' +
       '<option value="accepted">Accepted</option>' +
       '<option value="any">Any</option>' +

--- a/inst/shiny/www/vegbank_app.js
+++ b/inst/shiny/www/vegbank_app.js
@@ -482,6 +482,36 @@ window.vbMapBindShinyInputs = function(map, el) {
   });
 };
 
+// Help/instructions button control — adds a square info button above the zoom controls
+// (top-left) that opens a Bootstrap popover with usage instructions.
+window.vbMapHelpControl = function(map, el, btnInnerHtml, closeIconHtml, contentHtml) {
+  var helpBtn = null;
+  var helpControl = L.control({position: 'topleft'});
+  helpControl.onAdd = function() {
+    var container = L.DomUtil.create('div', 'leaflet-bar leaflet-control vb-map-help-control');
+    helpBtn = L.DomUtil.create('a', 'vb-map-help-btn vb-help-btn', container);
+    helpBtn.href = '#';
+    helpBtn.setAttribute('role', 'button');
+    helpBtn.setAttribute('title', 'About this map');
+    helpBtn.setAttribute('aria-label', 'About this map');
+    helpBtn.innerHTML = btnInnerHtml;
+    L.DomEvent.disableClickPropagation(container);
+    L.DomEvent.on(helpBtn, 'click', L.DomEvent.preventDefault);
+    return container;
+  };
+  helpControl.addTo(map);
+
+  // Move the help control to the top of the top-left stack (above zoom +/-)
+  var topLeft = el.querySelector('.leaflet-top.leaflet-left');
+  if (topLeft && topLeft.children.length > 1) {
+    topLeft.insertBefore(topLeft.lastElementChild, topLeft.firstElementChild);
+  }
+
+  if (helpBtn && window.vbHelpButton) {
+    window.vbHelpButton(helpBtn, '<strong>Map</strong>', contentHtml, closeIconHtml);
+  }
+};
+
 // Inject the status <label> into the .dataTables_filter area on table init.
 // Called from each concept table's initComplete callback. Uses the Shiny
 // output div id (same resolution as registerDataTableMapping) to look up config.

--- a/inst/shiny/www/vegbank_app.js
+++ b/inst/shiny/www/vegbank_app.js
@@ -482,6 +482,31 @@ window.vbMapBindShinyInputs = function(map, el) {
   });
 };
 
+// Set up the status filter dropdown in the Communities table toolbar.
+// Injected via the table's initComplete callback so it sits to the left of the
+// search bar, inside the DT Buttons bar.
+// window.vbCommStatus persists the selected value across table re-renders.
+window.vbSetupCommStatusDropdown = function(nTableWrapper) {
+  var btnBar = $(nTableWrapper).find('.dt-buttons');
+  if (!btnBar.length || btnBar.find('.vb-status-select-wrapper').length) return;
+  var currentVal = window.vbCommStatus || 'current_accepted';
+  var $wrapper = $('<label class="vb-status-select-wrapper">' +
+    '<span class="vb-status-select-label">Status:</span>' +
+    '<select class="vb-status-select">' +
+      '<option value="current_accepted">Current &amp; Accepted</option>' +
+      '<option value="current">Current</option>' +
+      '<option value="accepted">Accepted</option>' +
+      '<option value="any">Any</option>' +
+    '</select>' +
+    '</label>');
+  $wrapper.find('select').val(currentVal);
+  btnBar.append($wrapper);
+  $wrapper.find('select').on('change', function() {
+    window.vbCommStatus = this.value;
+    Shiny.setInputValue('comm_status', this.value, {priority: 'event'});
+  });
+};
+
 // Help/instructions button control — adds a square info button above the zoom controls
 // (top-left) that opens a Bootstrap popover with usage instructions.
 window.vbMapHelpControl = function(map, el, btnInnerHtml, closeIconHtml, contentHtml) {

--- a/inst/shiny/www/vegbank_app.js
+++ b/inst/shiny/www/vegbank_app.js
@@ -493,7 +493,9 @@ var vbConceptStatusConfigs = {
 window.vbConceptStatusInit = function(nTableWrapper, tableId) {
   var config = vbConceptStatusConfigs[tableId];
   if (!config) return;
-  var validStatuses = ['current_accepted', 'current', 'accepted', 'any'];
+  // Guard against double-injection (e.g. if initComplete fires twice on the same wrapper).
+  if ($(nTableWrapper).find('.vb-status-label').length) return;
+  var validStatuses = window.VB_VALID_CONCEPT_STATUSES || ['current_accepted', 'current', 'accepted', 'any'];
   var urlVal    = new URLSearchParams(window.location.search).get(config.urlKey);
   var storedVal = window[config.windowVar];
   var initVal   = (storedVal && validStatuses.indexOf(storedVal) !== -1)

--- a/inst/shiny/www/vegbank_app.js
+++ b/inst/shiny/www/vegbank_app.js
@@ -482,25 +482,23 @@ window.vbMapBindShinyInputs = function(map, el) {
   });
 };
 
-// Set up the status filter dropdown in the Communities table toolbar.
-// Injected via the table's initComplete callback so it sits to the left of the
-// search bar, inside the DT Buttons bar.
-// The selected value is persisted in the URL as `communities_status` and
-// restored on page reload via window.vbCommStatus (set by setCommStatus handler).
-window.vbSetupCommStatusDropdown = function(nTableWrapper) {
+// Shared factory for the concept status dropdown.
+// Injected via each table's initComplete callback, just to the left of the search bar.
+// config: { urlKey, windowVar, cssClass, shinyInput, paginationKey }
+function vbSetupConceptStatusDropdown(nTableWrapper, config) {
   var $filter = $(nTableWrapper).find('.dataTables_filter');
   if (!$filter.length || $(nTableWrapper).find('.vb-status-select-wrapper').length) return;
-  // Prefer the in-memory value (set by setCommStatus on URL restore) over the URL
-  // directly, to stay in sync with what the server has already applied.
-  var urlParams = new URLSearchParams(window.location.search);
+  // Prefer the in-memory value (set by the server on URL restore) over the raw URL param
+  // so the dropdown always reflects what the server has already applied.
   var validStatuses = ['current_accepted', 'current', 'accepted', 'any'];
-  var urlStatus = urlParams.get('communities_status');
-  var currentVal = (window.vbCommStatus && validStatuses.indexOf(window.vbCommStatus) !== -1)
-    ? window.vbCommStatus
+  var urlStatus = new URLSearchParams(window.location.search).get(config.urlKey);
+  var storedVal = window[config.windowVar];
+  var currentVal = (storedVal && validStatuses.indexOf(storedVal) !== -1)
+    ? storedVal
     : (urlStatus && validStatuses.indexOf(urlStatus) !== -1 ? urlStatus : 'current_accepted');
   var $wrapper = $('<label class="vb-status-select-wrapper">' +
     '<span class="vb-status-select-label">Status:</span>' +
-    '<select class="vb-comm-status-select vb-status-select">' +
+    '<select class="' + config.cssClass + ' vb-status-select">' +
       '<option value="current_accepted">Currently Accepted</option>' +
       '<option value="current">Current</option>' +
       '<option value="accepted">Accepted</option>' +
@@ -510,76 +508,50 @@ window.vbSetupCommStatusDropdown = function(nTableWrapper) {
   $wrapper.find('select').val(currentVal);
   $filter.after($wrapper);
   $wrapper.find('select').on('change', function() {
-    window.vbCommStatus = this.value;
-    // Write communities_status to the URL and reset pagination before Shiny rebuilds.
+    window[config.windowVar] = this.value;
     var params = new URLSearchParams(window.location.search);
     if (this.value === 'current_accepted') {
-      params.delete('communities_status');
+      params.delete(config.urlKey);
     } else {
-      params.set('communities_status', this.value);
+      params.set(config.urlKey, this.value);
     }
-    if (params.has('communities_start')) {
-      params.set('communities_start', '0');
+    if (params.has(config.paginationKey)) {
+      params.set(config.paginationKey, '0');
     }
     var newSearch = params.toString();
     history.replaceState(null, '', newSearch ? '?' + newSearch : window.location.pathname);
-    Shiny.setInputValue('comm_status', this.value, {priority: 'event'});
+    Shiny.setInputValue(config.shinyInput, this.value, {priority: 'event'});
+  });
+}
+
+window.vbSetupCommStatusDropdown = function(nTableWrapper) {
+  vbSetupConceptStatusDropdown(nTableWrapper, {
+    urlKey: 'communities_status',
+    windowVar: 'vbCommStatus',
+    cssClass: 'vb-comm-status-select',
+    shinyInput: 'comm_status',
+    paginationKey: 'communities_start'
   });
 };
 
-// Receive the current communities status from the server (e.g. on URL restore)
-// and update the dropdown to match without triggering a redundant Shiny input.
+window.vbSetupPlantStatusDropdown = function(nTableWrapper) {
+  vbSetupConceptStatusDropdown(nTableWrapper, {
+    urlKey: 'plants_status',
+    windowVar: 'vbPlantStatus',
+    cssClass: 'vb-plant-status-select',
+    shinyInput: 'plant_status',
+    paginationKey: 'plants_start'
+  });
+};
+
 Shiny.addCustomMessageHandler('setCommStatus', function(message) {
-  var val = message.value;
-  window.vbCommStatus = val;
-  // Update any rendered dropdown immediately
-  $('.vb-comm-status-select').val(val);
+  window.vbCommStatus = message.value;
+  $('.vb-comm-status-select').val(message.value);
 });
 
-// Set up the status filter dropdown in the Plants table toolbar.
-window.vbSetupPlantStatusDropdown = function(nTableWrapper) {
-  var $filter = $(nTableWrapper).find('.dataTables_filter');
-  if (!$filter.length || $(nTableWrapper).find('.vb-status-select-wrapper').length) return;
-  var urlParams = new URLSearchParams(window.location.search);
-  var validStatuses = ['current_accepted', 'current', 'accepted', 'any'];
-  var urlStatus = urlParams.get('plants_status');
-  var currentVal = (window.vbPlantStatus && validStatuses.indexOf(window.vbPlantStatus) !== -1)
-    ? window.vbPlantStatus
-    : (urlStatus && validStatuses.indexOf(urlStatus) !== -1 ? urlStatus : 'current_accepted');
-  var $wrapper = $('<label class="vb-status-select-wrapper">' +
-    '<span class="vb-status-select-label">Status:</span>' +
-    '<select class="vb-plant-status-select vb-status-select">' +
-      '<option value="current_accepted">Currently Accepted</option>' +
-      '<option value="current">Current</option>' +
-      '<option value="accepted">Accepted</option>' +
-      '<option value="any">Any</option>' +
-    '</select>' +
-    '</label>');
-  $wrapper.find('select').val(currentVal);
-  $filter.after($wrapper);
-  $wrapper.find('select').on('change', function() {
-    window.vbPlantStatus = this.value;
-    var params = new URLSearchParams(window.location.search);
-    if (this.value === 'current_accepted') {
-      params.delete('plants_status');
-    } else {
-      params.set('plants_status', this.value);
-    }
-    if (params.has('plants_start')) {
-      params.set('plants_start', '0');
-    }
-    var newSearch = params.toString();
-    history.replaceState(null, '', newSearch ? '?' + newSearch : window.location.pathname);
-    Shiny.setInputValue('plant_status', this.value, {priority: 'event'});
-  });
-};
-
-// Receive the current plants status from the server (e.g. on URL restore)
-// and update the dropdown to match without triggering a redundant Shiny input.
 Shiny.addCustomMessageHandler('setPlantStatus', function(message) {
-  var val = message.value;
-  window.vbPlantStatus = val;
-  $('.vb-plant-status-select').val(val);
+  window.vbPlantStatus = message.value;
+  $('.vb-plant-status-select').val(message.value);
 });
 
 // Shared helper — set up a toggleable info popover on a DT help button.

--- a/inst/shiny/www/vegbank_app.js
+++ b/inst/shiny/www/vegbank_app.js
@@ -485,11 +485,19 @@ window.vbMapBindShinyInputs = function(map, el) {
 // Set up the status filter dropdown in the Communities table toolbar.
 // Injected via the table's initComplete callback so it sits to the left of the
 // search bar, inside the DT Buttons bar.
-// window.vbCommStatus persists the selected value across table re-renders.
+// The selected value is persisted in the URL as `communities_status` and
+// restored on page reload via window.vbCommStatus (set by setCommStatus handler).
 window.vbSetupCommStatusDropdown = function(nTableWrapper) {
   var btnBar = $(nTableWrapper).find('.dt-buttons');
   if (!btnBar.length || btnBar.find('.vb-status-select-wrapper').length) return;
-  var currentVal = window.vbCommStatus || 'current_accepted';
+  // Prefer the in-memory value (set by setCommStatus on URL restore) over the URL
+  // directly, to stay in sync with what the server has already applied.
+  var urlParams = new URLSearchParams(window.location.search);
+  var validStatuses = ['current_accepted', 'current', 'accepted', 'any'];
+  var urlStatus = urlParams.get('communities_status');
+  var currentVal = (window.vbCommStatus && validStatuses.indexOf(window.vbCommStatus) !== -1)
+    ? window.vbCommStatus
+    : (urlStatus && validStatuses.indexOf(urlStatus) !== -1 ? urlStatus : 'current_accepted');
   var $wrapper = $('<label class="vb-status-select-wrapper">' +
     '<span class="vb-status-select-label">Status:</span>' +
     '<select class="vb-status-select">' +
@@ -503,17 +511,30 @@ window.vbSetupCommStatusDropdown = function(nTableWrapper) {
   btnBar.append($wrapper);
   $wrapper.find('select').on('change', function() {
     window.vbCommStatus = this.value;
-    // Reset communities_start to 0 in the URL so that when Shiny rebuilds the
-    // table and vegbankLoadTableState re-reads the URL during init, it starts
-    // at page 1 instead of a potentially out-of-range offset.
+    // Write communities_status to the URL and reset pagination before Shiny rebuilds.
     var params = new URLSearchParams(window.location.search);
+    if (this.value === 'current_accepted') {
+      params.delete('communities_status');
+    } else {
+      params.set('communities_status', this.value);
+    }
     if (params.has('communities_start')) {
       params.set('communities_start', '0');
-      history.replaceState(null, '', '?' + params.toString());
     }
+    var newSearch = params.toString();
+    history.replaceState(null, '', newSearch ? '?' + newSearch : window.location.pathname);
     Shiny.setInputValue('comm_status', this.value, {priority: 'event'});
   });
 };
+
+// Receive the current communities status from the server (e.g. on URL restore)
+// and update the dropdown to match without triggering a redundant Shiny input.
+Shiny.addCustomMessageHandler('setCommStatus', function(message) {
+  var val = message.value;
+  window.vbCommStatus = val;
+  // Update any rendered dropdown immediately
+  $('.vb-status-select').val(val);
+});
 
 // Help/instructions button control — adds a square info button above the zoom controls
 // (top-left) that opens a Bootstrap popover with usage instructions.

--- a/inst/shiny/www/vegbank_styles.css
+++ b/inst/shiny/www/vegbank_styles.css
@@ -235,6 +235,30 @@ h1[id], h2[id], h3[id], h4[id], h5[id], h6[id] {
   transform: rotate(0deg) scale(1);
 }
 
+/* Status filter dropdown — sits inline to the right of DT Buttons */
+.dt-buttons .vb-status-select-wrapper {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-left: 0.5rem;
+  vertical-align: middle;
+}
+
+.dt-buttons .vb-status-select-label {
+  font-size: 0.875rem;
+  user-select: none;
+  white-space: nowrap;
+}
+
+.dt-buttons .vb-status-select {
+  font-size: 0.875rem;
+  padding: 0.1rem 0.4rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  background-color: #fff;
+  cursor: pointer;
+}
+
 .datatables .dataTables_wrapper div.dataTables_info {
   padding-top: 0.75rem;
   font-size: 0.875rem !important;

--- a/inst/shiny/www/vegbank_styles.css
+++ b/inst/shiny/www/vegbank_styles.css
@@ -235,18 +235,15 @@ h1[id], h2[id], h3[id], h4[id], h5[id], h6[id] {
   transform: rotate(0deg) scale(1);
 }
 
-/* Status filter dropdown — floats right, just to the left of the DT search bar */
-.vb-status-select-wrapper {
+.vb-status-label {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
   float: right;
-  margin-top: 0.3rem;
+  margin-top: 0.25rem;
   margin-right: 0.75rem;
-}
-
-.vb-status-select-label {
   font-size: 0.875rem;
+  cursor: default;
   user-select: none;
   white-space: nowrap;
 }

--- a/inst/shiny/www/vegbank_styles.css
+++ b/inst/shiny/www/vegbank_styles.css
@@ -26,13 +26,13 @@
   --border-subtle: hsl(0, 0%, 92%);
   --text-muted: #333;
 
-  /* Status badge colors */
-  --no-status-bg: hsl(204, 6%, 90%);
-  --no-status-text: hsl(0, 0%, 20%);
-  --accepted-bg: hsl(153, 31%, 79%);
-  --accepted-text: hsl(152, 69%, 19%);
-  --not-current-bg: hsl(45, 100%, 85%);
-  --not-current-text: hsl(45, 94%, 21%);
+  /* Badge colors */
+  --monochrome-bg: hsl(204, 6%, 90%);
+  --monochrome-text: hsl(0, 0%, 20%);
+  --green-bg: hsl(153, 31%, 79%);
+  --green-text: hsl(152, 69%, 19%);
+  --yellow-bg: hsl(45, 100%, 85%);
+  --yellow-text: hsl(45, 94%, 21%);
 }
 
 /* Adjust navbar height for mobile when toggler is visible */
@@ -393,7 +393,7 @@ table.dataTable tbody tr.selected-entity:hover,
 
 .loading-title {
   font-size: 0.875rem;
-  color: var(--no-status-text);
+  color: var(--monochrome-text);
   margin: 0 1.5rem 1.5rem;
 }
 
@@ -406,7 +406,7 @@ table.dataTable tbody tr.selected-entity:hover,
 
 .loading-detail {
   font-size: 0.875rem;
-  color: var(--no-status-text);
+  color: var(--monochrome-text);
   margin-bottom: 1.5rem;
 }
 

--- a/inst/shiny/www/vegbank_styles.css
+++ b/inst/shiny/www/vegbank_styles.css
@@ -235,22 +235,23 @@ h1[id], h2[id], h3[id], h4[id], h5[id], h6[id] {
   transform: rotate(0deg) scale(1);
 }
 
-/* Status filter dropdown — sits inline to the right of DT Buttons */
-.dt-buttons .vb-status-select-wrapper {
+/* Status filter dropdown — floats right, just to the left of the DT search bar */
+.vb-status-select-wrapper {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
-  margin-left: 0.5rem;
-  vertical-align: middle;
+  float: right;
+  margin-top: 0.3rem;
+  margin-right: 0.75rem;
 }
 
-.dt-buttons .vb-status-select-label {
+.vb-status-select-label {
   font-size: 0.875rem;
   user-select: none;
   white-space: nowrap;
 }
 
-.dt-buttons .vb-status-select {
+.vb-status-select {
   font-size: 0.875rem;
   padding: 0.1rem 0.4rem;
   border: 1px solid #ccc;

--- a/tests/testthat/test_community_table.R
+++ b/tests/testthat/test_community_table.R
@@ -21,8 +21,9 @@ test_that("build_community_table delegates to concept builder with community con
 })
 
 test_that("community concept data includes community-specific values", {
-  cols <- c("cc_code", "comm_name", "comm_level", "current_accepted",
-            "concept_rf_code", "concept_rf_label", "obs_count", "comm_description")
+  cols <- c("cc_code", "comm_name", "comm_level",
+            "concept_rf_code", "concept_rf_label", "obs_count", "comm_description",
+            "status", "stop_date")
   community_data <- rbind(
     mock_comm_concept_cegl007230[, cols],
     mock_comm_concept_brachypodium[, cols],
@@ -47,10 +48,12 @@ test_that("community concept data includes community-specific values", {
     expect_true(grepl("Quercus alba",  result$`Community Concept`[1]))
     expect_true(grepl("Brachypodium",  result$`Community Concept`[2]))
     expect_equal(result$`Community Concept`[3], "VII")
-    # Status: CEGL=Accepted (TRUE), Brachypodium=Not Current (FALSE), VII=Not Current (FALSE)
-    expect_true(grepl("Accepted",    result$Status[1]))
-    expect_true(grepl("Not Current", result$Status[2]))
-    expect_true(grepl("Not Current", result$Status[3]))
+    # Status: CEGL=Currently Accepted, Brachypodium=Not Accepted+Current, VII=Accepted+Not Current
+    expect_true(grepl("Currently Accepted", result$Status[1]))
+    expect_true(grepl("Not Accepted",         result$Status[2]))
+    expect_false(grepl("Not Current",       result$Status[2]))
+    expect_true(grepl("Not Current",        result$Status[3]))
+    expect_true(grepl("Accepted",           result$Status[3]))
     # Level
     expect_equal(result$Level, c("Association", "Association", "Class"))
     # Reference source: all three have valid concept_rf_code → all links

--- a/tests/testthat/test_concept_table.R
+++ b/tests/testthat/test_concept_table.R
@@ -45,8 +45,9 @@ test_that("build_concept_table configures datatable with hidden sort columns", {
 })
 
 # Real API data: ACRU (accepted, 0 obs), Vaccinium (no status, 828 obs), PSME (not current, 7475 obs)
-.pc_fields <- c("pc_code", "plant_name", "current_accepted", "plant_level",
-                "concept_rf_code", "concept_rf_label", "obs_count", "plant_description")
+.pc_fields <- c("pc_code", "plant_name", "plant_level",
+                "concept_rf_code", "concept_rf_label", "obs_count", "plant_description",
+                "status", "stop_date")
 plant_test_data <- rbind(
   mock_plant_concept_acru[, .pc_fields],
   mock_plant_concept_vaccinium[, .pc_fields],
@@ -54,11 +55,12 @@ plant_test_data <- rbind(
 )
 rm(.pc_fields)
 
-# Real API data: CEGL007230 (accepted, 294 obs, has description),
-#                Brachypodium (not current/undetermined, 17 obs, no description),
-#                VII (not current, 0 obs, no description)
-.cc_fields <- c("cc_code", "comm_name", "current_accepted", "comm_level",
-                "concept_rf_code", "concept_rf_label", "obs_count", "comm_description")
+# Real API data: CEGL007230 (accepted + current, 294 obs, has description),
+#                Brachypodium (Not Accepted + current, 17 obs, no description),
+#                VII (accepted + not current, 0 obs, no description)
+.cc_fields <- c("cc_code", "comm_name", "comm_level",
+                "concept_rf_code", "concept_rf_label", "obs_count", "comm_description",
+                "status", "stop_date")
 community_test_data <- rbind(
   mock_comm_concept_cegl007230[, .cc_fields],
   mock_comm_concept_brachypodium[, .cc_fields],
@@ -79,9 +81,10 @@ test_that("process_concept_data formats plant concepts", {
     expect_equal(result$`VegBank Code`, vapply(plant_test_data$pc_code, htmltools::htmlEscape, character(1), USE.NAMES = FALSE))
     expect_equal(result$`Plant Concept`,
       c("Acer rubrum L.", "Vaccinium stamineum", "Pseudotsuga menziesii (Mirbel) Franco"))
-    expect_true(grepl("Accepted",    result$Status[1]))  # ACRU: current_accepted=TRUE
-    expect_true(grepl("No Status",   result$Status[2]))  # Vaccinium: current_accepted=NA
-    expect_true(grepl("Not Current", result$Status[3]))  # PSME: current_accepted=FALSE
+    expect_true(grepl("Currently Accepted", result$Status[1]))  # ACRU: accepted + current
+    expect_true(grepl("No Status",          result$Status[2]))  # Vaccinium: status=NA
+    expect_true(grepl("Not Current",        result$Status[3]))  # PSME: accepted + not current
+    expect_true(grepl("Accepted",           result$Status[3]))  # PSME: still has Accepted badge
     expect_equal(result$Level, c("Species", "Unspecified", "Species"))
     expect_true(all(grepl("<a ", result$`Reference Source`)))  # all three have valid ref codes
     expect_equal(result$Plots[1], "0")                  # ACRU: obs_count=0 (no link)
@@ -113,9 +116,11 @@ test_that("process_concept_data formats community concepts", {
       "Brachypodium distachyon \u2013 Bromus diandrus / Quercus douglasii Semi-natural Association",
       "VII"
     ))
-    expect_true(grepl("Accepted",    result$Status[1]))  # CEGL007230: current_accepted=TRUE
-    expect_true(grepl("Not Current", result$Status[2]))  # Brachypodium: current_accepted=FALSE
-    expect_true(grepl("Not Current", result$Status[3]))  # VII: current_accepted=FALSE
+    expect_true(grepl("Currently Accepted", result$Status[1]))  # CEGL007230: accepted + current
+    expect_true(grepl("Not Accepted",         result$Status[2]))  # Brachypodium: Not Accepted + current
+    expect_false(grepl("Not Current",       result$Status[2]))  # Brachypodium: IS current
+    expect_true(grepl("Not Current",        result$Status[3]))  # VII: accepted + not current
+    expect_true(grepl("Accepted",           result$Status[3]))  # VII: still has Accepted badge
     expect_equal(result$Level, c("Association", "Association", "Class"))
     expect_true(all(grepl("<a ", result$`Reference Source`)))  # all three have valid ref codes
     expect_true(grepl(">294</a>",  result$Plots[1]))   # CEGL007230: 294

--- a/tests/testthat/test_plant_table.R
+++ b/tests/testthat/test_plant_table.R
@@ -21,8 +21,9 @@ test_that("build_plant_table delegates to concept builder with plant config", {
 })
 
 test_that("plant concept data includes plant-specific values", {
-  cols <- c("pc_code", "plant_name", "plant_level", "current_accepted",
-            "concept_rf_code", "concept_rf_label", "obs_count", "plant_description")
+  cols <- c("pc_code", "plant_name", "plant_level",
+            "concept_rf_code", "concept_rf_label", "obs_count", "plant_description",
+            "status", "stop_date")
   plant_data <- rbind(
     mock_plant_concept_acru[, cols],
     mock_plant_concept_vaccinium[, cols],
@@ -46,10 +47,11 @@ test_that("plant concept data includes plant-specific values", {
     expect_equal(result$`Plant Concept`[1], "Acer rubrum L.")
     expect_true(grepl("Vaccinium stamineum", result$`Plant Concept`[2]))
     expect_true(grepl("Pseudotsuga menziesii", result$`Plant Concept`[3]))
-    # Status: ACRU=Accepted (TRUE), Vaccinium=No Status (NA), PSME=Not Current (FALSE)
-    expect_true(grepl("Accepted",   result$Status[1]))
-    expect_true(grepl("No Status",  result$Status[2]))
-    expect_true(grepl("Not Current", result$Status[3]))
+    # Status: ACRU=Currently Accepted, Vaccinium=No Status, PSME=Accepted + Not Current
+    expect_true(grepl("Currently Accepted", result$Status[1]))
+    expect_true(grepl("No Status",          result$Status[2]))
+    expect_true(grepl("Not Current",        result$Status[3]))
+    expect_true(grepl("Accepted",           result$Status[3]))
     # Level
     expect_equal(result$Level, c("Species", "Unspecified", "Species"))
     # Reference source: all three have valid concept_rf_code → all links


### PR DESCRIPTION
## What
Closes #178 and #177 by adding drop downs to filter the Plants and Communities table concepts by Any, Current, Accepted, and Currently Accepted status and showing currently accepted concepts by default.

## Why
Because the api supports this and it's a user-desired behavior that will help emphasize the more relevant and recent data.

## How

- Created a status dropdown added to the DOM near the table filter after it initializes
- Changed the filter behavior to reload the table content by proxy to so the dropdown doesn't flicker out of view when you change status while loading data
- Encode the status filter values to and restore them from the URL
- Ensure changing the status filter resets the table to the first page as well
- Consolidate validation logic for status values to an R constant that's passed to JS

## Testing and Documentation
All 1366 tests pass and check() results in same 3 notes.