### PR TITLE
Bugfix 210 status filter would hide citation data

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -1699,6 +1699,9 @@ server <- function(input, output, session) {
 
   shiny::observeEvent(input$clear_plot_filter, {
     state$plot_filter(NULL)
+    # Restore default plot status now that the filter is cleared
+    state$plot_status("current")
+    session$sendCustomMessage("setPlotStatus", list(value = "current"))
     # Clear plots table state (including search) when clearing filter
     # This ensures we start fresh without any stale search terms
     state$table_states[["plots"]] <- NULL

--- a/R/server.R
+++ b/R/server.R
@@ -82,10 +82,10 @@ server <- function(input, output, session) {
     map_has_custom_state = shiny::reactiveVal(FALSE),
     map_request = shiny::reactiveVal(NULL),
     plot_filter = shiny::reactiveVal(NULL), # Cross-resource / citation filter: list(type, code, label)
-    plot_status = shiny::reactiveVal("current"), # Status filter for plot observations table
+    plot_status = shiny::reactiveVal(DEFAULT_PLOT_STATUS), # Status filter for plot observations table
     community_filter = shiny::reactiveVal(NULL), # Citation filter for cc: list(type, code, label)
-    community_status = shiny::reactiveVal("current_accepted"), # Status filter for community concepts table
-    plant_status = shiny::reactiveVal("current_accepted"), # Status filter for plant concepts table
+    community_status = shiny::reactiveVal(DEFAULT_CONCEPT_STATUS), # Status filter for community concepts table
+    plant_status = shiny::reactiveVal(DEFAULT_CONCEPT_STATUS), # Status filter for plant concepts table
     table_states = shiny::reactiveValues(),
     table_sync_pending = shiny::reactiveValues(),
     table_sync_completed_at = shiny::reactiveValues()
@@ -1511,15 +1511,15 @@ server <- function(input, output, session) {
       }
       restore_status_param(params$communities_status, state$community_status, "setCommStatus",
         valid_statuses = VALID_CONCEPT_STATUSES,
-        default_status = "current_accepted"
+        default_status = DEFAULT_CONCEPT_STATUS
       )
       restore_status_param(params$plants_status, state$plant_status, "setPlantStatus",
         valid_statuses = VALID_CONCEPT_STATUSES,
-        default_status = "current_accepted"
+        default_status = DEFAULT_CONCEPT_STATUS
       )
       restore_status_param(params$plots_status, state$plot_status, "setPlotStatus",
         valid_statuses = VALID_PLOT_STATUSES,
-        default_status = "current"
+        default_status = DEFAULT_PLOT_STATUS
       )
 
       # Parse and apply map view state
@@ -1700,8 +1700,8 @@ server <- function(input, output, session) {
   shiny::observeEvent(input$clear_plot_filter, {
     state$plot_filter(NULL)
     # Restore default plot status now that the filter is cleared
-    state$plot_status("current")
-    session$sendCustomMessage("setPlotStatus", list(value = "current"))
+    state$plot_status(DEFAULT_PLOT_STATUS)
+    session$sendCustomMessage("setPlotStatus", list(value = DEFAULT_PLOT_STATUS))
     # Clear plots table state (including search) when clearing filter
     # This ensures we start fresh without any stale search terms
     state$table_states[["plots"]] <- NULL

--- a/R/server.R
+++ b/R/server.R
@@ -511,6 +511,9 @@ server <- function(input, output, session) {
 
     if (is_dataset) {
       state$plot_filter(filter_info)
+      # Reset plot status to "any" so no observations are hidden when arriving via citation.
+      state$plot_status("any")
+      session$sendCustomMessage("setPlotStatus", list(value = "any"))
       state$current_tab("Plots")
       shiny::updateNavbarPage(session, "page", selected = "Plots")
 
@@ -528,6 +531,7 @@ server <- function(input, output, session) {
         detail_code = citation$vb_code
       )
     } else {
+      # Only one entity in table so no need to deal with status
       if (citation$tab == "Plots") {
         state$plot_filter(filter_info)
         state$highlighted_table("plot_table")
@@ -1677,6 +1681,11 @@ server <- function(input, output, session) {
       code = vb_code,
       label = label %||% vb_code
     ))
+
+    # Reset plot status to "any" so no observations are hidden by the status filter
+    # when the user first arrives via a cross-resource filter (e.g. obs_count click).
+    state$plot_status("any")
+    session$sendCustomMessage("setPlotStatus", list(value = "any"))
 
     # Clear plots table state (including search) when applying cross-resource filter
     # This prevents old search terms from being carried over to the filtered view

--- a/R/table_concept.R
+++ b/R/table_concept.R
@@ -3,8 +3,9 @@
 #' Provides server-side DataTable builders for plant and community concepts.
 #' @noRd
 
-# Valid values for the concept status filter, shared between server logic and URL restore.
+# Valid values and default for the concept status filter, shared between server logic and URL restore.
 VALID_CONCEPT_STATUSES <- c("any", "current", "accepted", "current_accepted")
+DEFAULT_CONCEPT_STATUS <- "current_accepted"
 
 CONCEPT_CONFIG <- list(
   plant = build_table_module_config(

--- a/R/table_plot.R
+++ b/R/table_plot.R
@@ -3,8 +3,9 @@
 #' Provides a remote (server-side) DataTable for VegBank plot observations.
 #' @noRd
 
-# Valid values for the plot status filter, shared between server logic and URL restore.
+# Valid values and default for the plot status filter, shared between server logic and URL restore.
 VALID_PLOT_STATUSES <- c("any", "current")
+DEFAULT_PLOT_STATUS <- "current"
 
 PLOT_TABLE_FIELDS <- c(
   "ob_code",

--- a/R/ui.R
+++ b/R/ui.R
@@ -68,7 +68,9 @@ ui <- function(req) {
     "window.DETAIL_TYPE_LABELS = {\n", detail_labels_js, "\n};\n",
     "window.DETAIL_ICONS = ", jsonlite::toJSON(DETAIL_ICONS, auto_unbox = TRUE), ";\n",
     "window.VB_VALID_CONCEPT_STATUSES = ", jsonlite::toJSON(VALID_CONCEPT_STATUSES), ";\n",
-    "window.VB_VALID_PLOT_STATUSES = ", jsonlite::toJSON(VALID_PLOT_STATUSES), ";\n"
+    "window.VB_VALID_PLOT_STATUSES = ",    jsonlite::toJSON(VALID_PLOT_STATUSES), ";\n",
+    "window.VB_DEFAULT_CONCEPT_STATUS = '", DEFAULT_CONCEPT_STATUS, "';\n",
+    "window.VB_DEFAULT_PLOT_STATUS = '",    DEFAULT_PLOT_STATUS, "';\n"
   )))
 
   # External JavaScript file with main application logic

--- a/R/ui.R
+++ b/R/ui.R
@@ -69,8 +69,8 @@ ui <- function(req) {
     "window.DETAIL_ICONS = ", jsonlite::toJSON(DETAIL_ICONS, auto_unbox = TRUE), ";\n",
     "window.VB_VALID_CONCEPT_STATUSES = ", jsonlite::toJSON(VALID_CONCEPT_STATUSES), ";\n",
     "window.VB_VALID_PLOT_STATUSES = ",    jsonlite::toJSON(VALID_PLOT_STATUSES), ";\n",
-    "window.VB_DEFAULT_CONCEPT_STATUS = '", DEFAULT_CONCEPT_STATUS, "';\n",
-    "window.VB_DEFAULT_PLOT_STATUS = '",    DEFAULT_PLOT_STATUS, "';\n"
+    "window.VB_DEFAULT_CONCEPT_STATUS = ", jsonlite::toJSON(DEFAULT_CONCEPT_STATUS, auto_unbox = TRUE), ";\n",
+    "window.VB_DEFAULT_PLOT_STATUS = ",    jsonlite::toJSON(DEFAULT_PLOT_STATUS,    auto_unbox = TRUE), ";\n"
   )))
 
   # External JavaScript file with main application logic

--- a/R/url_state_manager.R
+++ b/R/url_state_manager.R
@@ -398,19 +398,19 @@ URLStateManager <- R6::R6Class(
 
       # Include plot status filter (omit when it's the default)
       if (!is.null(plot_status) && nzchar(plot_status) &&
-          !identical(plot_status, "current")) {
+          !identical(plot_status, DEFAULT_PLOT_STATUS)) {
         params$plots_status <- plot_status
       }
 
       # Include community status filter (omit when it's the default)
       if (!is.null(community_status) && nzchar(community_status) &&
-          !identical(community_status, "current_accepted")) {
+          !identical(community_status, DEFAULT_CONCEPT_STATUS)) {
         params$communities_status <- community_status
       }
 
       # Include plant status filter (omit when it's the default)
       if (!is.null(plant_status) && nzchar(plant_status) &&
-          !identical(plant_status, "current_accepted")) {
+          !identical(plant_status, DEFAULT_CONCEPT_STATUS)) {
         params$plants_status <- plant_status
       }
 

--- a/inst/shiny/www/vegbank_app.js
+++ b/inst/shiny/www/vegbank_app.js
@@ -519,21 +519,21 @@ var vbStatusConfigs = {
   plant_table: {
     urlKey: 'plants_status', windowVar: 'vbPlantStatus', cssClass: 'vb-plant-status-select',
     shinyInput: 'plant_status', paginationKey: 'plants_start',
-    defaultStatus: 'current_accepted',
+    defaultStatus: window.VB_DEFAULT_CONCEPT_STATUS || 'current_accepted',
     validStatuses: function() { return window.VB_VALID_CONCEPT_STATUSES || ['current_accepted', 'current', 'accepted', 'any']; },
     optionsHtml: '<option value="current_accepted">Currently Accepted</option><option value="current">Current</option><option value="accepted">Accepted</option><option value="any">Any</option>'
   },
   comm_table: {
     urlKey: 'communities_status', windowVar: 'vbCommStatus', cssClass: 'vb-comm-status-select',
     shinyInput: 'comm_status', paginationKey: 'communities_start',
-    defaultStatus: 'current_accepted',
+    defaultStatus: window.VB_DEFAULT_CONCEPT_STATUS || 'current_accepted',
     validStatuses: function() { return window.VB_VALID_CONCEPT_STATUSES || ['current_accepted', 'current', 'accepted', 'any']; },
     optionsHtml: '<option value="current_accepted">Currently Accepted</option><option value="current">Current</option><option value="accepted">Accepted</option><option value="any">Any</option>'
   },
   plot_table: {
     urlKey: 'plots_status', windowVar: 'vbPlotStatus', cssClass: 'vb-plot-status-select',
     shinyInput: 'plot_status', paginationKey: 'plots_start',
-    defaultStatus: 'current',
+    defaultStatus: window.VB_DEFAULT_PLOT_STATUS || 'current',
     validStatuses: function() { return window.VB_VALID_PLOT_STATUSES || ['current', 'any']; },
     optionsHtml: '<option value="current">Current</option><option value="any">Any</option>'
   }


### PR DESCRIPTION
## What
Closes #210 by ensuring that cited datasets and observation count filters resolve to a Plots table with "Any" status instead of the default "Current." Also updates the default status configs to be sourced from the relevant plot tables and ensures that clearing the filter returns to a plots table filtered to Current status.

## Why
Before this the status filter would result no plot obs would get listed for some datasets or projects (like https://dev.vegbank.org/beta/?cite=ds.199699) even though the dataset metadata says there should be (996 plots).

## How

- Updated server.R to apply an Any status filter in state before populating the table with a filter or citation
- Added new constants to table_plot and table_concept to source defaults in server.R and the vegbank_app.js files

## Testing and Documentation
All 1577 tests pass and check() results in same 3 notes.